### PR TITLE
Allow mongomock.Connection's constructor to take in a variable number of arguments with *args.

### DIFF
--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -56,7 +56,7 @@ def resolve_key_value(key, doc):
             return resolve_key_value(sub_key, sub_doc)
 
 class Connection(object):
-    def __init__(self):
+    def __init__(self, *args):
         super(Connection, self).__init__()
         self._databases = {}
     def __getitem__(self, db_name):


### PR DESCRIPTION
arguments with *args.

This will let it work with code that uses the optional arguments in
pymongo.Connection's constructor:
https://github.com/mongodb/mongo-python-driver/blob/eeef9179ecde3a2e9fb55d0b33735302df19b83a/pymongo/connection.py#L83
