### PR TITLE
fix for ObjectId.__str__ to return str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ pip-log.txt
 .project
 .metadata
 
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea
 
 #### Emacs
 \#*\#

--- a/mongomock/object_id.py
+++ b/mongomock/object_id.py
@@ -1,9 +1,12 @@
 import uuid
 
 class ObjectId(object):
-    def __init__(self):
+    def __init__(self, id=None):
         super(ObjectId, self).__init__()
-        self._id = uuid.uuid1()
+        if id is None:
+            self._id = uuid.uuid1()
+        else:
+            self._id = uuid.UUID(id)
     def __eq__(self, other):
         return isinstance(other, ObjectId) and other._id == self._id
     def __ne__(self, other):
@@ -13,4 +16,4 @@ class ObjectId(object):
     def __repr__(self):
         return 'ObjectId({})'.format(self._id)
     def __str__(self):
-        return self._id
+        return str(self._id)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -307,3 +307,9 @@ class UpdateTest(DocumentTest):
         doc = self.collection.find_one({'name': 'bob'})
         self.assertEqual(doc['name'], 'bob')
         self.assertEqual(doc['hat'], 'red')
+
+class ObjectIdTest(TestCase):
+    def test__equal_with_same_id(self):
+        obj1 = ObjectId()
+        obj2 = ObjectId(str(obj1))
+        self.assertEqual(obj1, obj2)


### PR DESCRIPTION
Hi,

Firstly, many thanks for starting this project.

A small fix to ObjectId as right now it raises an error:
`TypeError: __str__ returned non-string (type UUID)`
and the optional 'id' argument for a constructor to be in line with bson ObjectId

Cheers,
catty
