### PR TITLE
Test that shows difference in "upsert" behavior

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -293,6 +293,12 @@ class CollectionTest(CollectionComparisonTest):
             self.cmp.do.update({'name':'bob'}, {'$inc': {'count':1}})
             self.cmp.compare.find({'name': 'bob'})
 
+    def test__inc_upsert(self):
+        self.cmp.do.remove()
+        for i in range(3):
+            self.cmp.do.update({'name':'bob'}, {'$inc': {'count':1}}, True)
+            self.cmp.compare.find({'name': 'bob'})
+
     def test__inc_subdocument(self):
         self.cmp.do.remove()
         self.cmp.do.insert({'name': 'bob', 'data': {'age': 0}})


### PR DESCRIPTION
As requested in [issue 15](https://github.com/vmalloc/mongomock/issues/15), here is a failing test that shows the issue I'm encountering.
