### PR TITLE
Obscure naming bug, under certain instances the mongomock returns something it shouldn't 

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -97,7 +97,6 @@ class CollectionAPITest(TestCase):
         self.assertNotIsInstance(collection.find(), tuple)
 
     def test__naming_bug(self):
-        names = ['test1', 'test2']
         self.db['abc'].save({'name':'test1'})
         self.db['abc'].save({'name':'test2'})
         #now searching for 'name':'e' returns test1


### PR DESCRIPTION
Do you have time to take a look at this? 
