### PR TITLE
Add support for calling find_one('id'), matching pymongo behavior.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ pip-log.txt
 #### Haskell
 *.hi
 flycheck-*
+.DS_Store

--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -334,6 +334,11 @@ class Collection(object):
         return (document for document in itervalues(self._documents) if self._filter_applies(filter, document))
 
     def find_one(self, spec_or_id=None, *args, **kwargs):
+        # Allow calling find_one with a non-dict argument that gets used as
+        # the id for the query.
+        if not hasattr(spec_or_id, 'iteritems'):
+            spec_or_id = {'_id':spec_or_id}
+
         try:
             return next(self.find(spec_or_id, *args, **kwargs))
         except StopIteration:

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -188,6 +188,7 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find_one({"_id" : "id1"})
         self.cmp.do.insert({"_id":"id2", "name" : "another new"})
         self.cmp.compare.find_one({"_id" : "id2"}, {"_id":1})
+        self.cmp.compare.find_one("id2", {"_id":1})
 
     def test__find_by_attributes(self):
         id1 = ObjectId()


### PR DESCRIPTION
The signature already called the argument "spec_or_id", but didn't support calling with just an id.
