### PR TITLE
Support for default write concern of "Acknowledged"

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -380,14 +380,14 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find()
         self.cmp.do.remove({'name': 'notsam'})
         self.cmp.compare.find()
-        self.cmp.do.remove({'name': 'sam'})
+        self.cmp.compare.remove({'name': 'sam'})
         self.cmp.compare.find
 
     def test__update(self):
         doc = {"a" : 1}
         self.cmp.do.insert(doc)
         new_document = {"new_attr" : 2}
-        self.cmp.do.update({"a" : 1}, new_document)
+        self.cmp.compare.update({"a" : 1}, new_document)
         self.cmp.compare_ignore_order.find()
 
     def test__set(self):


### PR DESCRIPTION
Write concern which appears to, in practice, be "Unacknowledged".  This is unlike the default write concern -- which is causing some of my tests to fail on operations that would otherwise pass in "real world" scenarios.
