### PR TITLE
Fix resolve_key_value to check for specific list items.

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -44,16 +44,31 @@ def resolve_key_value(key, doc):
     Resolve keys to their proper value in a document.
     Returns the appropriate nested value if the key includes dot notation.
     """
-    if not doc or not isinstance(doc, dict):
+    if not doc:
         return NOTHING
-    else:
+
+    if isinstance(doc, list):
         key_parts = key.split('.')
+        try:
+            search_key = int(key_parts[0])
+        except ValueError:
+            return NOTHING
+        sub_doc = doc[search_key]
         if len(key_parts) == 1:
-            return doc.get(key, NOTHING)
-        else:
-            sub_key = '.'.join(key_parts[1:])
-            sub_doc = doc.get(key_parts[0], {})
-            return resolve_key_value(sub_key, sub_doc)
+            return sub_doc
+        sub_key = '.'.join(key_parts[1:])
+        return resolve_key_value(sub_key, sub_doc)
+
+    if not isinstance(doc, dict):
+        return NOTHING
+
+    key_parts = key.split('.')
+    if len(key_parts) == 1:
+        return doc.get(key, NOTHING)
+
+    sub_key = '.'.join(key_parts[1:])
+    sub_doc = doc.get(key_parts[0], {})
+    return resolve_key_value(sub_key, sub_doc)
 
 def _force_list(v):
     return v if isinstance(v, (list, tuple)) else [v]

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -284,6 +284,14 @@ class _CollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find({"field": {"$elemMatch": {"a": 1}}})
         self.cmp.compare.find({"field": {"$elemMatch": {"b": {"$gt": 3}}}})
 
+    def test__find_in_array(self):
+        self.cmp.do.insert({"field": [{"a": 1, "b": 2}, {"c": 3, "d": 4}]})
+
+        self.cmp.compare.find({"field.0.a": 1})
+        self.cmp.compare.find({"field.0.b": 2})
+        self.cmp.compare.find({"field.1.c": 3})
+        self.cmp.compare.find({"field.1.d": 4})
+
     def test__find_notequal(self):
         """Test searching with operators other than equality."""
         bob = {'_id': 1, 'name': 'bob'}


### PR DESCRIPTION
It looks like mongomock wasn't allowing for searches such as `{"item.0.field": 5}`
