### PR TITLE
Make sub-collections accessible by __getattr__ and __getitem__.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -37,6 +37,12 @@ class Collection(object):
 
     def __repr__(self):
         return "Collection({0}, '{1}')".format(self._Collection__database, self.name)
+    
+    def __getitem__(self, name):
+        return self._Collection__database[self.name + '.' + name]
+    
+    def __getattr__(self, name):
+        return self.__getitem__(name)
 
     def insert(self, data):
         if isinstance(data, list):


### PR DESCRIPTION
pymongo supports this:

```
>>> import pymongo
>>> foo = pymongo.Connection()
>>> foo.db.bar
Collection(Database(Connection('localhost', 27017), u'db'), u'bar')
>>> foo.db.bar['baz']
Collection(Database(Connection('localhost', 27017), u'db'), u'bar.baz')
>>> foo.db.bar.baz
Collection(Database(Connection('localhost', 27017), u'db'), u'bar.baz')
```
