### PR TITLE
fixing "global name DuplicateKeyError is not defined" error

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from sentinels import NOTHING
 from .filtering import filter_applies, resolve_key_value
-from . import ObjectId, OperationFailure
+from . import ObjectId, OperationFailure, DuplicateKeyError
 from .helpers import basestring
 
 try:


### PR DESCRIPTION
I was running some tests and ran into the following error:

```
  File ".../mongomock/mongomock/collection.py", line 59, in _insert
    raise DuplicateKeyError("Duplicate Key Error", 11000)
NameError: global name 'DuplicateKeyError' is not defined
```

This fixes it.
