### PR TITLE
Add arguments to Collection.insert

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -47,7 +47,8 @@ class Collection(object):
     def __getattr__(self, name):
         return self.__getitem__(name)
 
-    def insert(self, data):
+    def insert(self, data, manipulate=True,
+               safe=None, check_keys=True, continue_on_error=False, **kwargs):
         if isinstance(data, list):
             return [self._insert(element) for element in data]
         return self._insert(data)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -117,6 +117,11 @@ class CollectionAPITest(TestCase):
             with self.assertRaises(ValueError):
                 self.db.col1.save({key: "value"})
 
+    def test__insert(self):
+        self.db.collection.insert({'a': 1})
+        self.db.collection.insert([{'a': 2}, {'a': 3}])
+        self.db.collection.insert({'a': 4}, safe=True, check_keys=False, continue_on_error=True)
+
     def test__find_returns_cursors(self):
         collection = self.db.collection
         self.assertEquals(type(collection.find()).__name__, "Cursor")


### PR DESCRIPTION
For compatibility with pymongo.Collection.insert

Otherwise, can be thrown `TypeError: insert() got an unexpected keyword argument 'safe'`
