### PR TITLE
allow with_limit_and_skip to be passed to cursor count method

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -602,11 +602,18 @@ class Cursor(object):
         else:
             self._dataset = iter(sorted(self._dataset, key = lambda x: _resolve_key(key_or_list, x), reverse = direction < 0))
         return self
-    def count(self):
+
+    def count(self, with_limit_and_skip=False):
         arr = [x for x in self._dataset]
         count = len(arr)
+        if with_limit_and_skip:
+            if self._skip:
+                count -= self._skip
+            if self._limit and count > self._limit:
+                count = self._limit
         self._dataset = iter(arr)
         return count
+
     def skip(self, count):
         self._skip = count
         return self

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -172,6 +172,22 @@ class CollectionAPITest(TestCase):
         self.assertTrue(isinstance(ret_val,list))
         self.assertTrue(set(ret_val) == set(['larry','gary']))
 
+    def test__cursor_count_with_limit(self):
+        first = {'name':'first'}
+        second = {'name':'second'}
+        third = {'name':'third'}
+        self.db['coll_name'].insert([first, second, third])
+        count = self.db['coll_name'].find().limit(2).count(with_limit_and_skip=True)
+        self.assertEqual(count, 2)
+
+    def test__cursor_count_with_skip(self):
+        first = {'name':'first'}
+        second = {'name':'second'}
+        third = {'name':'third'}
+        self.db['coll_name'].insert([first, second, third])
+        count = self.db['coll_name'].find().skip(1).count(with_limit_and_skip=True)
+        self.assertEqual(count, 2)
+
     def test__find_with_skip_param(self):
         """
         Make sure that find() will take in account skip parametter


### PR DESCRIPTION
Add optional with_limit_and_skip argument to cursor count method to match pymongo.
