### PR TITLE
Connection.__init__(): set document_class

### DIFF
--- a/mongomock/connection.py
+++ b/mongomock/connection.py
@@ -13,6 +13,7 @@ class Connection(object):
         self.port = port
         self._databases = {}
         self._id = next(self._CONNECTION_ID)
+        self.document_class = document_class
 
     def __getitem__(self, db_name):
         db = self._databases.get(db_name, None)


### PR DESCRIPTION
pymongo's Connection class exposes the document_class as a property, this change does the same for mongomock's Connection
