### PR TITLE
Added Python 3.4 and PyPy to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "pypy"
 env:
   - INSTALL_PYMONGO=true INSTALL_PYEXECJS=true
   - INSTALL_PYMONGO=false INSTALL_PYEXECJS=false
 services:
   - mongodb
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# command to install dependencies, e.g. pip install -r requirements.txt
 install: 
   - python setup.py develop
-  - pip install --use-mirrors nose
+  - travis_retry pip install nose
 # command to run tests, e.g. python setup.py test
 script: nosetests -w tests


### PR DESCRIPTION
Also --use-mirrors is deprecated. Use travis_retry instead in order to avoid build failures caused by network problems.
