### PR TITLE
refs #114: Added alive method to Connection

### DIFF
--- a/mongomock/connection.py
+++ b/mongomock/connection.py
@@ -74,6 +74,14 @@ class Connection(object):
                 drop_collections_for_db(db)
                 del self._databases[name_or_db]
 
+    def alive(self):
+        """The original MongoConnection.alive method checks the
+        status of the server.
+
+        In our case as we mock the actual server, we should always return True.
+        """
+        return True
+
 
 # Connection is now depricated, it's called MongoClient instead
 class MongoClient(Connection):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -90,6 +90,8 @@ class DatabaseGettingTest(TestCase):
 
         self.assertEqual(qr.count(), 0)
 
+    def test__alive(self):
+        self.assertTrue(self.conn.alive())
 
 @skipIf(not _HAVE_PYMONGO,"pymongo not installed")
 class _CollectionComparisonTest(TestCase):


### PR DESCRIPTION
This method is pretty basic. Normally it would check it can open a
socket to the server. As there is no server (we are mocking it), it
simply returns True.
