### PR TITLE
fix average in python2 using from __future__ import division

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import collections
 from collections import OrderedDict
 import copy


### PR DESCRIPTION
Hi,

Using python2, the follwing tests fail:
- test__mongomock.MongoClientAggregateTest.test__aggregate5
- test__mongomock.MongoClientAggregateTest.test__aggregate7

Indeed, since python default division is integer division the following average calculation doesn't give the same result as pymongo $avg:

*line 1417 of collection.py:  current_avg = current_val / max(len(group_list), 1)*
