### PR TITLE
add support for $group on embedded dictionaries

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1266,7 +1266,7 @@ class Collection(object):
             out_field = key.split('__')[0]
 
             for doc in out_collection:
-                if key not in doc.keys():
+                if '__' in key:
                     func_field = key.split('__')[1]
                     func, in_field = func_field.split('_')
                     out_value = doc.get(in_field)
@@ -1382,7 +1382,10 @@ class Collection(object):
                     if len(group_func_keys) == 0:
                         grouped_collection = []
                     else:
-                        out_collection = sorted(out_collection, key=itemgetter(*group_func_keys))
+                        out_collection = sorted(out_collection,
+                                                key=itemgetter(*map(lambda x: x.split('.')[0],
+                                                                    group_func_keys)))
+
                     for field, value in iteritems(v):
                         if field == '_id':
                             continue
@@ -1392,7 +1395,8 @@ class Collection(object):
                                     grouped = itertools.groupby(out_collection)
                                 else:
                                     grouped = itertools.groupby(out_collection,
-                                                                itemgetter(*group_func_keys))
+                                                                helpers.embedded_item_getter(
+                                                                    *group_func_keys))
 
                                 for ret_value, group in grouped:
                                     group_list = ([x for x in group])

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -187,3 +187,35 @@ def parse_dbase_from_uri(uri):
         dbase = unquote_plus(dbase)
 
     return dbase
+
+
+def embedded_item_getter(*keys):
+    """Get items from embedded dictionaries.
+
+    use case:
+    d = {"a": {"b": 1}}
+    embedded_item_getter("a.b")(d) == 1
+
+    :param keys: keys to get
+                 embedded keys are separated with dot in string
+    :return: itemgetter function
+    """
+
+    def recurse_embedded(obj, key):
+        ret = obj
+        for k in key.split('.'):
+            ret = ret[k]
+        return ret
+
+    if len(keys) == 1:
+        item = keys[0]
+
+        def g(obj):
+            return recurse_embedded(obj, item)
+
+    else:
+
+        def g(obj):
+            return tuple(recurse_embedded(obj, item) for item in keys)
+
+    return g

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from mongomock.helpers import embedded_item_getter
 from mongomock.helpers import hashdict
 from mongomock.helpers import parse_dbase_from_uri
 from mongomock.helpers import print_deprecation_warning
@@ -92,3 +93,8 @@ def create_uri_spec_tests():
 
 
 create_uri_spec_tests()
+
+
+class TestHelpers(TestCase):
+    def test01_embedded_item_getter(self):
+        assert embedded_item_getter("a.b", "c", "a")({"a": {"b": 1}, "c": 5}) == (1, 5, {"b": 1})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1549,6 +1549,25 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         ]
         self.cmp.compare.aggregate(pipeline)
 
+    def test__aggregate10(self):     # group on compound index
+        self.cmp.do.remove()
+
+        data = [
+            {"_id": ObjectId(),
+             "key_1": {"sub_key_1": "value_1"}, "nb": 1},
+            {"_id": ObjectId(),
+             "key_1": {"sub_key_1": "value_2"}, "nb": 1},
+            {"_id": ObjectId(),
+             "key_1": {"sub_key_1": "value_1"}, "nb": 2}
+        ]
+        for item in data:
+            self.cmp.do.insert(item)
+
+        pipeline = [
+            {'$group': {"_id": "$key_1.sub_key_1", "nb": {"$sum": "$nb"}}},
+        ]
+        self.cmp.compare_ignore_order.aggregate(pipeline)
+
 
 def _LIMIT(*args):
     return lambda cursor: cursor.limit(*args)


### PR DESCRIPTION
Hi,

For my use case, I need to use $group on embedded dictionaries :

document = {"key_1": {"sub_key_1": "value_1"}, "nb": 1}
aggregation_pipeline = [{'$group': {"_id": "$key_1.sub_key_1", "nb": {"$sum": "$nb"}}}]

Would you be interested in merging this functionality ?
This would be helpful for me, then I wouldn't have to keep my own version of mongomock.
(and I will probably have to add other functionalities)

If you have any comment, don't hesitate.

Thank you