### PR TITLE
Fix skipping of MongoClientAggregateTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
 script:
   - tox -e $TOX_ENV
 before_install:
-  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
+  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927"
+  - "echo 'deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.2 multiverse' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list"
   - "sudo apt-get update"
   - "sudo apt-get install mongodb-org-server"
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ basepython =
 deps=
     nose
     pymongo: pymongo<4.0.0
+             pyexecjs
     pyexecjs: pyexecjs
-commands= nosetests -x -s {posargs}
+commands= nosetests -v -x -s {posargs}
 
 [testenv:pep8]
 basepython = python2


### PR DESCRIPTION
As discussed in #237, tests that require both pymongo and pyexecjs aren't being run at all since there is no tox factor which includes both. To fix this, I've just added the pyexecjs dependency to the pymongo dependencies. I'll add the commit that fixes the failing tests after the CI runs
