### PR TITLE
collection: fix out_collection sorted key itemgetter 

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -7,7 +7,6 @@ import functools
 import itertools
 import json
 import math
-from operator import itemgetter
 import threading
 import time
 import warnings
@@ -1497,8 +1496,7 @@ class Collection(object):
                         grouped_collection = []
                     else:
                         out_collection = sorted(out_collection,
-                                                key=itemgetter(*map(lambda x: x.split('.')[0],
-                                                                    group_func_keys)))
+                                                key=helpers.embedded_item_getter(*group_func_keys))
 
                     for field, value in iteritems(v):
                         if field == '_id':


### PR DESCRIPTION
As noticed by @drorasaf in PR #258, test_aggregate10 failed with python3 after merge of PR #254. 
This commit fixes it.