### PR TITLE
collection: name func params same as pymongo3

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -320,20 +320,20 @@ class Collection(object):
             sub_doc = sub_doc[part]
         del sub_doc[key_parts[-1]]
 
-    def update_one(self, criteria, update, upsert=False):
+    def update_one(self, filter, update, upsert=False):
         validate_ok_for_update(update)
-        return UpdateResult(self._update(criteria, update, upsert=upsert),
+        return UpdateResult(self._update(filter, update, upsert=upsert),
                             acknowledged=True)
 
-    def update_many(self, criteria, update, upsert=False):
+    def update_many(self, filter, update, upsert=False):
         validate_ok_for_update(update)
-        return UpdateResult(self._update(criteria, update, upsert=upsert,
+        return UpdateResult(self._update(filter, update, upsert=upsert,
                                          multi=True),
                             acknowledged=True)
 
-    def replace_one(self, criteria, replacement, upsert=False):
+    def replace_one(self, filter, replacement, upsert=False):
         validate_ok_for_replace(replacement)
-        return UpdateResult(self._update(criteria, replacement, upsert=upsert),
+        return UpdateResult(self._update(filter, replacement, upsert=upsert),
                             acknowledged=True)
 
     def update(self, spec, document, upsert=False, manipulate=False,

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -390,7 +390,9 @@ class CollectionAPITest(TestCase):
     def test__update_one(self):
         insert_result = self.db.collection.insert_one({'a': 1})
         update_result = self.db.collection.update_one(
-            {'a': 1}, {'$set': {'a': 2}})
+            filter={'a': 1},
+            update={'$set': {'a': 2}}
+        )
         self.assertEqual(update_result.matched_count, 1)
         self.assertEqual(update_result.modified_count, 1)
         self.assertIsNone(update_result.upserted_id)
@@ -401,7 +403,10 @@ class CollectionAPITest(TestCase):
     def test__update_one_upsert(self):
         self.assert_document_count(0)
         update_result = self.db.collection.update_one(
-            {'a': 1}, {'$set': {'a': 1}}, upsert=True)
+            filter={'a': 1},
+            update={'$set': {'a': 1}},
+            upsert=True
+        )
         self.assertEqual(update_result.modified_count, 0)
         self.assertEqual(update_result.matched_count, 0)
         self.assertIsNotNone(update_result.upserted_id)
@@ -410,7 +415,10 @@ class CollectionAPITest(TestCase):
     def test__update_one_upsert_dots(self):
         self.assert_document_count(0)
         update_result = self.db.collection.update_one(
-            {'a.b': 1}, {'$set': {'c': 2}}, upsert=True)
+            filter={'a.b': 1},
+            update={'$set': {'c': 2}},
+            upsert=True
+        )
         self.assertEqual(update_result.modified_count, 0)
         self.assertEqual(update_result.matched_count, 0)
         self.assertIsNotNone(update_result.upserted_id)
@@ -419,7 +427,10 @@ class CollectionAPITest(TestCase):
     def test__update_one_upsert_invalid_filter(self):
         with self.assertRaises(mongomock.WriteError):
             self.db.collection.update_one(
-                {'a.b': 1, 'a': 3}, {'$set': {'c': 2}}, upsert=True)
+                filter={'a.b': 1, 'a': 3},
+                update={'$set': {'c': 2}},
+                upsert=True
+            )
 
     def test__update_many(self):
         self.db.collection.insert_many([
@@ -428,7 +439,9 @@ class CollectionAPITest(TestCase):
             {'a': 2, 'c': 4}
         ])
         update_result = self.db.collection.update_many(
-            {'a': 1}, {'$set': {'c': 0}})
+            filter={'a': 1},
+            update={'$set': {'c': 0}}
+        )
         self.assertEqual(update_result.modified_count, 2)
         self.assertEqual(update_result.matched_count, 2)
         self.assertIsNone(update_result.upserted_id)
@@ -439,7 +452,10 @@ class CollectionAPITest(TestCase):
     def test__update_many_upsert(self):
         self.assert_document_count(0)
         update_result = self.db.collection.update_many(
-            {'a': 1}, {'$set': {'a': 1, 'c': 0}}, upsert=True)
+            filter={'a': 1},
+            update={'$set': {'a': 1, 'c': 0}},
+            upsert=True
+        )
         self.assertEqual(update_result.modified_count, 0)
         self.assertEqual(update_result.matched_count, 0)
         self.assertIsNotNone(update_result.upserted_id)
@@ -449,12 +465,18 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert({'a': 1, 'b': 2})
         self.assert_documents([{'a': 1, 'b': 2}])
 
-        result = self.db.collection.replace_one({'a': 2}, {'x': 1, 'y': 2})
+        result = self.db.collection.replace_one(
+            filter={'a': 2},
+            replacement={'x': 1, 'y': 2}
+        )
         self.assert_documents([{'a': 1, 'b': 2}])
         self.assertEqual(result.matched_count, 0)
         self.assertEqual(result.modified_count, 0)
 
-        result = self.db.collection.replace_one({'a': 1}, {'x': 1, 'y': 2})
+        result = self.db.collection.replace_one(
+            filter={'a': 1},
+            replacement={'x': 1, 'y': 2}
+        )
         self.assert_documents([{'x': 1, 'y': 2}])
         self.assertEqual(result.matched_count, 1)
         self.assertEqual(result.modified_count, 1)
@@ -462,7 +484,10 @@ class CollectionAPITest(TestCase):
     def test__replace_one_upsert(self):
         self.assert_document_count(0)
         result = self.db.collection.replace_one(
-            {'a': 2}, {'x': 1, 'y': 2}, upsert=True)
+            filter={'a': 2},
+            replacement={'x': 1, 'y': 2},
+            upsert=True
+        )
         self.assertEqual(result.matched_count, 0)
         self.assertEqual(result.modified_count, 0)
         self.assertIsNotNone(result.upserted_id)


### PR DESCRIPTION
- Rename update_one, update_many, and replace_one function parameters to
  be consistent with pymongo3
- Update tests to use keyword args when calling these functions