### PR TITLE
fix for updating with {}

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -584,6 +584,12 @@ class Collection(object):
                         raise ValueError(
                             'Invalid modifier specified: {}'.format(k))
                 first = False
+            # if empty document comes
+            if len(document) == 0:
+                _id = spec.get('_id', existing_document.get('_id'))
+                existing_document.clear()
+                if _id:
+                    existing_document['_id'] = _id
             if not multi:
                 break
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -761,6 +761,12 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             {'a.b': 1}, {'$set': {'c': 2}}, upsert=True)
         self.cmp.compare.find()
 
+    def test__update_with_empty_document_comes(self):
+        """Tests calling update with just '{}' for replacing whole document"""
+        self.cmp.do.insert({'name': 'bob', 'hat': 'wide'})
+        self.cmp.do.update({'name': 'bob'}, {})
+        self.cmp.compare.find()
+
     def test__update_one(self):
         self.cmp.do.insert_many([{'a': 1, 'b': 0},
                                  {'a': 2, 'b': 0}])


### PR DESCRIPTION
When calling `update({'name': 'bob'}, {})` it must clear document like in real mongo, but now it leaves document unchanged.