### PR TITLE
Return the copy of the document, not the actual document.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1640,7 +1640,7 @@ class Cursor(object):
             raise StopIteration()
         if self._limit is not None:
             self._emitted += 1
-        return next(self._dataset)
+        return {k: copy.deepcopy(v) for k, v in iteritems(next(self._dataset))}
     next = __next__
 
     def rewind(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -117,6 +117,15 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(StopIteration):
             next(iterator2)
 
+    def test_cursor_returns_document_copies(self):
+        obj = {'a': 1, 'b': 2}
+        self.db.collection.insert(obj)
+        fetched_obj = self.db.collection.find_one({'a': 1})
+        self.assertEqual(fetched_obj, obj)
+        fetched_obj['b'] = 3
+        refetched_obj = self.db.collection.find_one({'a': 1})
+        self.assertNotEqual(fetched_obj, refetched_obj)
+
     def test__update_retval(self):
         self.db.col.save({"a": 1})
         retval = self.db.col.update({"a": 1}, {"b": 2})


### PR DESCRIPTION
This only addresses the problem when fetching a document from the collection or through a find operation.

I have not checked when fetching a document through the aggregation pipeline.

This addresses issue #290.