### PR TITLE
Fix cursor.__getitem__ behavior

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1747,9 +1747,14 @@ class Cursor(object):
         return list(unique) + unique_dict_vals
 
     def __getitem__(self, index):
-        arr = [x for x in self._dataset]
-        self._dataset = iter(arr)
-        return arr[index]
+        if isinstance(index, slice):
+            # Limit the cursor to the given slice
+            self._dataset = (x for x in list(self._dataset)[index])
+            return self
+        else:
+            arr = [x for x in self._dataset]
+            self._dataset = iter(arr)
+            return arr[index]
 
 
 def _set_updater(doc, field_name, value):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1751,6 +1751,10 @@ class Cursor(object):
             # Limit the cursor to the given slice
             self._dataset = (x for x in list(self._dataset)[index])
             return self
+        elif not isinstance(index, int):
+            raise TypeError("index '%s' cannot be applied to Cursor instances" % index)
+        elif index < 0:
+            raise IndexError('Cursor instances do not support negativeindices')
         else:
             arr = [x for x in self._dataset]
             self._dataset = iter(arr)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -587,6 +587,24 @@ class CollectionAPITest(TestCase):
         count = cursor.count()
         self.assertEqual(count, 2)
 
+    def test__cursor_getitem_negative_index(self):
+        first = {'name': 'first'}
+        second = {'name': 'second'}
+        third = {'name': 'third'}
+        self.db['coll_name'].insert([first, second, third])
+        cursor = self.db['coll_name'].find()
+        with self.assertRaises(IndexError):
+            cursor[-1]
+
+    def test__cursor_getitem_bad_index(self):
+        first = {'name': 'first'}
+        second = {'name': 'second'}
+        third = {'name': 'third'}
+        self.db['coll_name'].insert([first, second, third])
+        cursor = self.db['coll_name'].find()
+        with self.assertRaises(TypeError):
+            cursor['not_a_number']
+
     def test__find_with_skip_param(self):
         """Make sure that find() will take in account skip parameter"""
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -567,6 +567,26 @@ class CollectionAPITest(TestCase):
             1).count(with_limit_and_skip=True)
         self.assertEqual(count, 2)
 
+    def test__cursor_getitem(self):
+        first = {'name': 'first'}
+        second = {'name': 'second'}
+        third = {'name': 'third'}
+        self.db['coll_name'].insert([first, second, third])
+        cursor = self.db['coll_name'].find()
+        item = cursor[0]
+        self.assertEqual(item['name'], 'first')
+
+    def test__cursor_getitem_slice(self):
+        first = {'name': 'first'}
+        second = {'name': 'second'}
+        third = {'name': 'third'}
+        self.db['coll_name'].insert([first, second, third])
+        cursor = self.db['coll_name'].find()
+        ret = cursor[1:4]
+        self.assertIs(ret, cursor)
+        count = cursor.count()
+        self.assertEqual(count, 2)
+
     def test__find_with_skip_param(self):
         """Make sure that find() will take in account skip parameter"""
 


### PR DESCRIPTION
According to pymongo documentation (http://api.mongodb.com/python/current/api/pymongo/cursor.html#pymongo.cursor.Cursor.__getitem__) `Cursor.__getitem__` should update itself when passing a slice instead of returning a list of results (current behavior).

This PR fix this.