### PR TITLE
Fix issue with skipping twice in find

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -32,7 +32,6 @@ from six import iteritems
 from six import iterkeys
 from six import itervalues
 from six import MAXSIZE
-from six.moves import xrange
 from six import string_types
 from six import text_type
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -709,7 +709,7 @@ class Collection(object):
         validate_is_mapping('filter', spec)
         return Cursor(self, spec, sort, projection, skip, limit)
 
-    def _get_dataset(self, spec, sort, fields, as_class, skip):
+    def _get_dataset(self, spec, sort, fields, as_class):
         dataset = (self._copy_only_fields(document, fields, as_class)
                    for document in self._iter_documents(spec))
         if sort:
@@ -717,12 +717,6 @@ class Collection(object):
                 dataset = iter(sorted(
                     dataset, key=lambda x: _resolve_sort_key(sortKey, x),
                     reverse=sortDirection < 0))
-        for i in xrange(skip):
-            try:
-                next(dataset)
-            except StopIteration:
-                pass
-
         return dataset
 
     def _copy_field(self, obj, container):
@@ -1698,7 +1692,7 @@ class Cursor(object):
         self._projection = projection
         self._skip = skip
         self._factory = functools.partial(collection._get_dataset,
-                                          spec, sort, projection, dict, skip)
+                                          spec, sort, projection, dict)
         # pymongo limit defaults to 0, returning everything
         self._limit = limit if limit != 0 else None
         self.rewind()
@@ -1800,7 +1794,7 @@ class Cursor(object):
         elif index < 0:
             raise IndexError('Cursor instances do not support negativeindices')
         else:
-            arr = [x for x in self._dataset]
+            arr = list(self)
             self._dataset = iter(arr)
             return arr[index]
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -601,6 +601,14 @@ class CollectionAPITest(TestCase):
             1).count(with_limit_and_skip=True)
         self.assertEqual(count, 2)
 
+    def test__cursor_count_with_skip_init(self):
+        first = {'name': 'first'}
+        second = {'name': 'second'}
+        third = {'name': 'third'}
+        self.db['coll_name'].insert([first, second, third])
+        count = self.db['coll_name'].find(skip=1).count(with_limit_and_skip=True)
+        self.assertEqual(count, 2)
+
     def test__cursor_getitem(self):
         first = {'name': 'first'}
         second = {'name': 'second'}
@@ -648,7 +656,7 @@ class CollectionAPITest(TestCase):
         self.assertEqual(
             self.db['users'].find(
                 sort=[
-                    ("name", 1)], skip=1).count(), 1)
+                    ("name", 1)], skip=1).count(with_limit_and_skip=True), 1)
         self.assertEqual(
             self.db['users'].find(
                 sort=[

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1765,6 +1765,9 @@ class MongoClientSortSkipLimitTest(_CollectionComparisonTest):
     def test__skip(self):
         self.cmp.compare(_SORT("index", 1), _SKIP(10)).find()
 
+    def test__skipped_find(self):
+        self.cmp.compare(_SORT("index", 1)).find(skip=10)
+
     def test__limit(self):
         self.cmp.compare(_SORT("index", 1), _LIMIT(10)).find()
 


### PR DESCRIPTION
41235a1 introduces a double 'skip', once in the dataset creation and once in the iteration.
We only need one, and for count to work (which ignores these params) we need it to be outside the dataset creation.