### PR TITLE
Multiple corrections (yeah sorry for that)

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -958,6 +958,9 @@ class Collection(object):
                 except ValueError:
                     pass
             elif isinstance(doc, dict):
+                if updater is _unset_updater and part not in doc:
+                    # If the parent doesn't exists, so does it child.
+                    return
                 doc = doc.setdefault(part, {})
             else:
                 return

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -405,7 +405,12 @@ class Collection(object):
                     continue
                 # For upsert operation we have first to create a fake existing_document,
                 # update it like a regular one, then finally insert it
-                _id = spec.get('_id') or document.get('_id') or ObjectId()
+                if spec.get('_id') is not None:
+                    _id = spec['_id']
+                elif document.get('_id') is not None:
+                    _id = document['_id']
+                else:
+                    _id = ObjectId()
                 to_insert = dict(spec, _id=_id)
                 to_insert = self._expand_dots(to_insert)
                 existing_document = to_insert

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1116,6 +1116,12 @@ class Collection(object):
     def drop_index(self, index_or_name):
         pass
 
+    def reindex(self):
+        pass
+
+    def list_indexes(self):
+        return {}
+
     def index_information(self):
         return {}
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -275,7 +275,11 @@ class Collection(object):
         self.full_name = "{0}.{1}".format(db.name, name)
         self.database = db
         self._documents = OrderedDict()
+        self._force_created = False
         self._uniques = []
+
+    def _is_created(self):
+        return self._documents or self._force_created
 
     def __repr__(self):
         return "Collection({0}, '{1}')".format(self.database, self.name)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -339,14 +339,14 @@ class Collection(object):
         if isinstance(object_id, dict):
             object_id = helpers.hashdict(object_id)
         if object_id in self._documents:
-            raise DuplicateKeyError("Duplicate Key Error", 11000)
+            raise DuplicateKeyError("E11000 Duplicate Key Error", 11000)
         for unique, is_sparse in self._uniques:
             find_kwargs = {}
             for key, direction in unique:
                 find_kwargs[key] = data.get(key, None)
             answer = self.find(find_kwargs)
             if answer.count() > 0 and not (is_sparse and find_kwargs[key] is None):
-                raise DuplicateKeyError("Duplicate Key Error", 11000)
+                raise DuplicateKeyError("E11000 Duplicate Key Error", 11000)
         with lock:
             self._documents[object_id] = self._internalize_dict(data)
         return data['_id']

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -279,7 +279,7 @@ class Collection(object):
         self._uniques = []
 
     def _is_created(self):
-        return self._documents or self._force_created
+        return self._documents or self._uniques or self._force_created
 
     def __repr__(self):
         return "Collection({0}, '{1}')".format(self.database, self.name)
@@ -1115,6 +1115,9 @@ class Collection(object):
 
     def drop_index(self, index_or_name):
         pass
+
+    def drop_indexes(self):
+        self._uniques = []
 
     def reindex(self):
         pass

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1742,6 +1742,7 @@ class Cursor(object):
     def clone(self):
         cursor = Cursor(self.collection,
                         self._spec, self._sort, self._projection, self._skip, self._limit)
+        cursor._factory = self._factory
         return cursor
 
     def __next__(self):

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -13,8 +13,7 @@ class Database(object):
     def __init__(self, client, name):
         self.name = name
         self._client = client
-        self._collections = {
-            'system.indexes': Collection(self, 'system.indexes')}
+        self._collections = {}
 
     def __getitem__(self, coll_name):
         return self.get_collection(coll_name)

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -55,12 +55,14 @@ class Database(object):
                 collection = next(c for c in self._collections.values() if c is name_or_collection)
                 collection._documents = OrderedDict()
                 collection._force_created = False
+                collection.drop_indexes()
             else:
                 if name_or_collection in self._collections:
                     collection = self._collections.get(name_or_collection)
                     if collection:
                         collection._documents = OrderedDict()
                         collection._force_created = False
+                        collection.drop_indexes()
         # EAFP paradigm
         # (http://en.m.wikipedia.org/wiki/Python_syntax_and_semantics)
         except Exception:

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -12,7 +12,10 @@ class MongoClient(object):
 
     def __init__(self, host=None, port=None, document_class=dict,
                  tz_aware=False, connect=True, **kwargs):
-        self.host = host or self.HOST
+        if host:
+            self.host = host[0] if isinstance(host, (list, tuple)) else host
+        else:
+            self.host = self.HOST
         self.port = port or self.PORT
         self._databases = {}
         self._id = next(self._CONNECTION_ID)

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -73,19 +73,13 @@ class MongoClient(object):
                 _db.drop_collection(col_name)
 
         if isinstance(name_or_db, Database):
-            databases_keys = list(self._databases.keys())
-            for database_name in databases_keys:
-                tmp_database = self._databases.get(database_name)
-                if tmp_database is name_or_db:
-                    if tmp_database:
-                        drop_collections_for_db(tmp_database)
-                    del self._databases[database_name]
-                    break
+            db = next(db for db in self._databases.values() if db is name_or_db)
+            if db:
+                drop_collections_for_db(db)
 
         elif name_or_db in self._databases:
             db = self._databases[name_or_db]
             drop_collections_for_db(db)
-            del self._databases[name_or_db]
 
     def get_database(self, name, codec_options=None, read_preference=None,
                      write_concern=None):

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -38,6 +38,14 @@ class MongoClient(object):
         pass
 
     @property
+    def is_mongos(self):
+        return True
+
+    @property
+    def is_primary(self):
+        return True
+
+    @property
     def address(self):
         return self.host, self.port
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -38,7 +38,7 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual(
             set(self.db.collection_names()),
-            set(["a.b", "system.indexes", "a"]))
+            set(["a.b", "a"]))
 
     def test__get_sibling_collection(self):
         self.db.a.database.b
@@ -52,8 +52,8 @@ class CollectionAPITest(TestCase):
     def test__get_collection_names(self):
         self.db.a
         self.db.b
-        self.assertEqual(set(self.db.collection_names()), set(['a', 'b', 'system.indexes']))
-        self.assertEqual(set(self.db.collection_names(True)), set(['a', 'b', 'system.indexes']))
+        self.assertEqual(set(self.db.collection_names()), set(['a', 'b']))
+        self.assertEqual(set(self.db.collection_names(True)), set(['a', 'b']))
         self.assertEqual(set(self.db.collection_names(False)), set(['a', 'b']))
 
         self.db.c.drop()
@@ -81,7 +81,7 @@ class CollectionAPITest(TestCase):
         self.db.drop_collection('b')
         self.db.drop_collection('b')
         self.db.drop_collection(self.db.c)
-        self.assertEqual(set(self.db.collection_names()), set(['a', 'system.indexes']))
+        self.assertEqual(set(self.db.collection_names()), set(['a']))
 
         col = self.db.a
         r = col.insert({"aa": "bb"})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -668,6 +668,19 @@ class CollectionAPITest(TestCase):
         count = self.db['coll_name'].find(skip=1).count(with_limit_and_skip=True)
         self.assertEqual(count, 2)
 
+    def test__cursor_count_when_db_changes(self):
+        self.db['coll_name'].insert({})
+        cursor = self.db['coll_name'].find()
+        self.db['coll_name'].insert({})
+        self.assertEqual(cursor.count(), 2)
+
+    def test__cursor_getitem_when_db_changes(self):
+        self.db['coll_name'].insert({})
+        cursor = self.db['coll_name'].find()
+        self.db['coll_name'].insert({})
+        cursor_items = [x for x in cursor]
+        self.assertEqual(len(cursor_items), 2)
+
     def test__cursor_getitem(self):
         first = {'name': 'first'}
         second = {'name': 'second'}

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -788,19 +788,19 @@ class CollectionAPITest(TestCase):
 
         self.db.collection.insert({})
         self.db.collection.insert({})
+        self.db.collection.insert({"value": None})
+        self.db.collection.insert({"value": None})
 
-        self.assertEqual(self.db.collection.find({}).count(), 2)
+        self.assertEqual(self.db.collection.find({}).count(), 4)
 
     def test_sparse_unique_index_dup(self):
         self.db.collection.ensure_index([("value", 1)], unique=True, sparse=True)
 
-        self.db.collection.insert({})
-        self.db.collection.insert({})
         self.db.collection.insert({'value': 'a'})
         with self.assertRaises(mongomock.DuplicateKeyError):
             self.db.collection.insert({'value': 'a'})
 
-        self.assertEqual(self.db.collection.find({}).count(), 3)
+        self.assertEqual(self.db.collection.find({}).count(), 1)
 
     def test__set_with_positional_operator(self):
         """Real mongodb support positional operator $ for $set operation"""

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -978,6 +978,24 @@ class CollectionAPITest(TestCase):
         self.assertEqual(
             list(self.db.collection.find({"checked": True})), list(self.db.collection.find()))
 
+    def test__cursor_sort_kept_after_clone(self):
+        self.db.collection.insert({"time_check": float(time.time())})
+        self.db.collection.insert({"time_check": float(time.time())})
+        self.db.collection.insert({"time_check": float(time.time())})
+
+        cursor = self.db.collection.find({}, sort=[('time_check', -1)])
+        cursor2 = cursor.clone()
+        cursor3 = self.db.collection.find({})
+        cursor3.sort([('time_check', -1)])
+        cursor4 = cursor3.clone()
+        cursor_result = list(cursor)
+        cursor2_result = list(cursor2)
+        cursor3_result = list(cursor3)
+        cursor4_result = list(cursor4)
+        self.assertEqual(cursor2_result, cursor_result)
+        self.assertEqual(cursor3_result, cursor_result)
+        self.assertEqual(cursor4_result, cursor_result)
+
     def test__avoid_change_data_after_set(self):
         test_data = {"test": ["test_data"]}
         self.db.collection.insert({"_id": 1})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -159,6 +159,20 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(StopIteration):
             next(iterator2)
 
+    def test__cursor_clone_keep_limit_skip(self):
+        self.db.collection.insert([{"a": "b"}, {"b": "c"}, {"c": "d"}])
+        cursor1 = self.db.collection.find()[1:2]
+        cursor2 = cursor1.clone()
+        result1 = list(cursor1)
+        result2 = list(cursor2)
+        self.assertEqual(result1, result2)
+
+        cursor3 = self.db.collection.find(skip=1, limit=1)
+        cursor4 = cursor3.clone()
+        result3 = list(cursor3)
+        result4 = list(cursor4)
+        self.assertEqual(result3, result4)
+
     def test_cursor_returns_document_copies(self):
         obj = {'a': 1, 'b': 2}
         self.db.collection.insert(obj)
@@ -654,6 +668,8 @@ class CollectionAPITest(TestCase):
         ret = cursor[1:4]
         self.assertIs(ret, cursor)
         count = cursor.count()
+        self.assertEqual(count, 3)
+        count = cursor.count(with_limit_and_skip=True)
         self.assertEqual(count, 2)
 
     def test__cursor_getitem_negative_index(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -107,6 +107,21 @@ class CollectionAPITest(TestCase):
         qr = col.find({"_id": r})
         self.assertEqual(qr.count(), 0)
 
+    def test__drop_collection_indexes(self):
+        col = self.db.a
+        col.create_index('simple')
+        col.create_index([("value", 1)], unique=True)
+        col.ensure_index([("sparsed", 1)], unique=True, sparse=True)
+
+        self.db.drop_collection(col)
+
+        # Make sure indexes' rules no longer apply
+        col.insert({'value': 'not_unique_but_ok', 'sparsed': 'not_unique_but_ok'})
+        col.insert({'value': 'not_unique_but_ok'})
+        col.insert({'sparsed': 'not_unique_but_ok'})
+        result = col.find({})
+        self.assertEqual(result.count(), 3)
+
     def test__drop_n_recreate_collection(self):
         col_a = self.db.create_collection('a')
         col_a2 = self.db.a

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -468,6 +468,28 @@ class CollectionAPITest(TestCase):
         doc.pop('_id')
         self.assertDictEqual(doc, update)
 
+    def test__iterate_on_find_and_update(self):
+        documents = [
+            {'x': 1, 's': 0},
+            {'x': 1, 's': 1},
+            {'x': 1, 's': 2},
+            {'x': 1, 's': 3}
+        ]
+        self.db.collection.insert_many(documents)
+        self.assert_documents(documents, ignore_ids=False)
+
+        cursor = self.db.collection.find({'x': 1})
+        self.assertEqual(cursor.count(), 4)
+
+        # Update the field used by the cursor's filter should not upset the iteration
+        for doc in cursor:
+            self.db.collection.update_one({'_id': doc['_id']}, {'$set': {'x': 2}})
+
+        cursor = self.db.collection.find({'x': 1})
+        self.assertEqual(cursor.count(), 0)
+        cursor = self.db.collection.find({'x': 2})
+        self.assertEqual(cursor.count(), 4)
+
     def test__update_interns_lists_and_dicts(self):
         obj = {}
         obj_id = self.db.collection.save(obj)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -40,6 +40,10 @@ class InterfaceTest(TestCase):
     def test__can_create_db_with_path(self):
         self.assertIsNotNone(mongomock.MongoClient('mongodb://localhost'))
 
+    def test__can_create_db_with_multiple_pathes(self):
+        hostnames = ['mongodb://localhost:27017', 'mongodb://localhost:27018']
+        self.assertIsNotNone(mongomock.MongoClient(hostnames))
+
     def test__repr(self):
         self.assertEqual(repr(mongomock.MongoClient()),
                          "mongomock.MongoClient('localhost', 27017)")
@@ -136,6 +140,8 @@ class DatabaseGettingTest(TestCase):
         c, db = gddb("mongodb://%24am:f%3Azzb%40zz@127.0.0.1/"
                      "admin%3F?authMechanism=MONGODB-CR")
         self.assertIs(db, c['admin?'])
+        c, db = gddb(['mongodb://localhost:27017/foo', 'mongodb://localhost:27018/foo'])
+        self.assertIs(db, c['foo'])
 
     def test__getting_default_database_invalid(self):
         def client(uri):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -105,6 +105,22 @@ class DatabaseGettingTest(TestCase):
         result = collection.find({"_id": doc_id})
         self.assertEqual(result.count(), 0)
 
+    def test__drop_database_indexes(self):
+        db = self.client.somedb
+        collection = db.a
+        collection.create_index('simple')
+        collection.create_index([("value", 1)], unique=True)
+        collection.ensure_index([("sparsed", 1)], unique=True, sparse=True)
+
+        self.client.drop_database("somedb")
+
+        # Make sure indexes' rules no longer apply
+        collection.insert({'value': 'not_unique_but_ok', 'sparsed': 'not_unique_but_ok'})
+        collection.insert({'value': 'not_unique_but_ok'})
+        collection.insert({'sparsed': 'not_unique_but_ok'})
+        result = collection.find({})
+        self.assertEqual(result.count(), 3)
+
     def test__alive(self):
         self.assertTrue(self.client.alive())
 


### PR DESCRIPTION
First, sorry for providing a big bunch of patches at once, however each commit consist of a single issue so I can provide custom cherry-picked PR if you wish to integrate only a subset of those patches.

- Fix cursor limit&skip when passed as slice
- Fix unique_index checking with upsert insertion
- Improve test_sparse_unique_index to test case field set to None (i.e. in mongo `{'field': None}` is equivalent to `{}`)
- Making reference to a collection in a driver doesn't create t in Mongo 
    Collection creation is lazy, i.e. a collection is created inside the database
    only when:
    - db.create_collection(<collection_name>) is explicitly called
    - a document is inserted into the collection
    - indexes are created for this collection
- MongoClient accept list of URIs as host param
- system.indexes is no longer defined by default (deprecated since MongoDB 3.0)
    See https://docs.mongodb.com/manual/release-notes/3.0-compatibility/#deprecate-access-to-system-indexes-and-system-namespaces
- Add MongoClient.is_mongos and MongoClient.is_primary
