### PR TITLE
Fix projection with subdocument arrays

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -810,7 +810,10 @@ class Collection(object):
                     doc_copy = self._copy_field(doc, container)
 
             else:
-                doc_copy = self._project_by_spec(doc, self._combine_projection_spec(fields), is_include=(list(fields.values())[0] == 1), container=container)
+                doc_copy = self._project_by_spec(doc,
+                                                 self._combine_projection_spec(fields),
+                                                 is_include=(list(fields.values())[0] == 1),
+                                                 container=container)
 
             # set the _id value if we requested it, otherwise remove it
             if id_value == 0:
@@ -828,10 +831,11 @@ class Collection(object):
             return doc_copy
 
     def _combine_projection_spec(self, projection_fields_spec):
-        """
-        Re-formats a projection fields spec into a nested dictionary:
+        """ Re-format a projection fields spec into a nested dictionary.
+        
         e.g: {'a': 1, 'b.c': 1, 'b.d': 1} => {'a': 1, 'b': {'c': 1, 'd': 1}}
         """
+
         tmp_spec = defaultdict(dict)
         for f, v in iteritems(projection_fields_spec):
             if '.' not in f:
@@ -872,7 +876,8 @@ class Collection(object):
                 else:
                     sub = doc[key]
                     if isinstance(sub, (list, tuple)):
-                        doc_copy[key] = [self._project_by_spec(sub_doc, spec, is_include, container) for sub_doc in sub]
+                        doc_copy[key] = [self._project_by_spec(sub_doc, spec, is_include, container)
+                                         for sub_doc in sub]
                     elif isinstance(sub, dict):
                         doc_copy[key] = self._project_by_spec(sub, spec, is_include, container)
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1,6 +1,6 @@
 from __future__ import division
 import collections
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import copy
 from datetime import datetime
 import functools
@@ -808,47 +808,9 @@ class Collection(object):
                     doc_copy = container()
                 else:
                     doc_copy = self._copy_field(doc, container)
-            # if 1 was passed in as the field values, include those fields
-            elif list(fields.values())[0] == 1:
-                doc_copy = container()
-                for key in fields:
-                    key_parts = key.split('.')
-                    subdocument = doc
-                    subdocument_copy = doc_copy
-                    last_copy = subdocument_copy
-                    full_key_path_found = True
-                    for key_part in key_parts[:-1]:
-                        if key_part not in subdocument:
-                            full_key_path_found = False
-                            break
-                        subdocument = subdocument[key_part]
-                        last_copy = subdocument_copy
-                        subdocument_copy = subdocument_copy.setdefault(key_part, {})
 
-                    if full_key_path_found:
-                        last_key = key_parts[-1]
-                        if isinstance(subdocument, dict) and last_key in subdocument:
-                            subdocument_copy[last_key] = subdocument[last_key]
-                        elif isinstance(subdocument, (list, tuple)):
-                            subdocument = [{last_key: x[last_key]}
-                                           for x in subdocument if last_key in x]
-                            if subdocument:
-                                last_copy[key_parts[-2]] = subdocument
-            # otherwise, exclude the fields passed in
             else:
-                doc_copy = self._copy_field(doc, container)
-                for key in fields:
-                    key_parts = key.split('.')
-                    subdocument_copy = doc_copy
-                    full_key_path_found = True
-                    for key_part in key_parts[:-1]:
-                        if key_part not in subdocument_copy:
-                            full_key_path_found = False
-                            break
-                        subdocument_copy = subdocument_copy[key_part]
-                    if not full_key_path_found or key_parts[-1] not in subdocument_copy:
-                        continue
-                    del subdocument_copy[key_parts[-1]]
+                doc_copy = self._project_by_spec(doc, self._combine_projection_spec(fields), is_include=(list(fields.values())[0] == 1), container=container)
 
             # set the _id value if we requested it, otherwise remove it
             if id_value == 0:
@@ -864,6 +826,63 @@ class Collection(object):
             for field, op in iteritems(projection_operators):
                 fields[field] = op
             return doc_copy
+
+    def _combine_projection_spec(self, projection_fields_spec):
+        """
+        Re-formats a projection fields spec into a nested dictionary:
+        e.g: {'a': 1, 'b.c': 1, 'b.d': 1} => {'a': 1, 'b': {'c': 1, 'd': 1}}
+        """
+        tmp_spec = defaultdict(dict)
+        for f, v in projection_fields_spec.iteritems():
+            if '.' not in f:
+                tmp_spec.setdefault(f, v)
+            else:
+                split_field = f.split('.', 1)
+                base_field, new_field = tuple(split_field)
+                if base_field in tmp_spec and not isinstance(tmp_spec[base_field], dict):
+                    tmp_spec[base_field] = {new_field: v}
+                else:
+                    tmp_spec[base_field][new_field] = v
+
+        combined_spec = {}
+        for f, v in tmp_spec.iteritems():
+            if not isinstance(v, dict):
+                combined_spec[f] = v
+            else:
+                combined_spec[f] = self._combine_projection_spec(v)
+
+        return combined_spec
+
+    def _project_by_spec(self, doc, combined_projection_spec, is_include, container):
+        doc_copy = container()
+        if not isinstance(doc, dict):
+            return doc_copy if is_include else doc
+
+        if not is_include:
+            # copy only scalar values
+            for key, val in doc.iteritems():
+                if not isinstance(val, (list, tuple, dict)):
+                    doc_copy[key] = val
+
+        for key, spec in combined_projection_spec.iteritems():
+            if key in doc:
+                if not isinstance(spec, dict):
+                    if is_include:
+                        doc_copy[key] = doc[key]
+                    else:
+                        doc_copy.pop(key)
+                else:
+                    sub = doc[key]
+                    if isinstance(sub, (list, tuple)):
+                        doc_copy[key] = [self._project_by_spec(sub_doc, spec, is_include, container) for sub_doc in sub]
+                    else:
+                        doc_copy[key] = self._project_by_spec(sub, spec, is_include, container)
+
+        new_container_type = type(container())
+        if all(isinstance(val, new_container_type) and not val for val in doc_copy.itervalues()):
+            return container()
+
+        return doc_copy
 
     def _update_document_fields(self, doc, fields, updater):
         """Implements the $set behavior on an existing document"""

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -833,7 +833,7 @@ class Collection(object):
         e.g: {'a': 1, 'b.c': 1, 'b.d': 1} => {'a': 1, 'b': {'c': 1, 'd': 1}}
         """
         tmp_spec = defaultdict(dict)
-        for f, v in projection_fields_spec.iteritems():
+        for f, v in iteritems(projection_fields_spec):
             if '.' not in f:
                 tmp_spec.setdefault(f, v)
             else:
@@ -845,7 +845,7 @@ class Collection(object):
                     tmp_spec[base_field][new_field] = v
 
         combined_spec = {}
-        for f, v in tmp_spec.iteritems():
+        for f, v in iteritems(tmp_spec):
             if not isinstance(v, dict):
                 combined_spec[f] = v
             else:
@@ -858,11 +858,11 @@ class Collection(object):
 
         if not is_include:
             # copy only scalar values
-            for key, val in doc.iteritems():
+            for key, val in iteritems(doc):
                 if not isinstance(val, (list, tuple, dict)):
                     doc_copy[key] = val
 
-        for key, spec in combined_projection_spec.iteritems():
+        for key, spec in iteritems(combined_projection_spec):
             if key in doc:
                 if not isinstance(spec, dict):
                     if is_include:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -855,8 +855,6 @@ class Collection(object):
 
     def _project_by_spec(self, doc, combined_projection_spec, is_include, container):
         doc_copy = container()
-        if not isinstance(doc, dict):
-            return doc_copy if is_include else doc
 
         if not is_include:
             # copy only scalar values
@@ -875,12 +873,8 @@ class Collection(object):
                     sub = doc[key]
                     if isinstance(sub, (list, tuple)):
                         doc_copy[key] = [self._project_by_spec(sub_doc, spec, is_include, container) for sub_doc in sub]
-                    else:
+                    elif isinstance(sub, dict):
                         doc_copy[key] = self._project_by_spec(sub, spec, is_include, container)
-
-        new_container_type = type(container())
-        if all(isinstance(val, new_container_type) and not val for val in doc_copy.itervalues()):
-            return container()
 
         return doc_copy
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -831,8 +831,8 @@ class Collection(object):
             return doc_copy
 
     def _combine_projection_spec(self, projection_fields_spec):
-        """ Re-format a projection fields spec into a nested dictionary.
-        
+        """Re-format a projection fields spec into a nested dictionary.
+
         e.g: {'a': 1, 'b.c': 1, 'b.d': 1} => {'a': 1, 'b': {'c': 1, 'd': 1}}
         """
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -903,12 +903,25 @@ class CollectionAPITest(TestCase):
         self.assertEqual(
             list(data_in_db), [{"_id": 1, "a": {"b": {"c": 2}}}])
 
-    def test_find_project_in_array(self):
-        self.db.collection.insert(
-            {'_id': 1, "list": [{"index": 1, "name": "name1"}, {"index": 2, "name": "name2"}]})
-        actual = self.db.collection.find(projection=['list.index'])
-        expect = [{'_id': 1, 'list': [{"index": 1}, {"index": 2}]}]
-        self.assertEqual(expect, list(actual))
+    def test__find_projection_with_subdoc_lists(self):
+        doc = {'a': 1, 'b': [{'c': 2, 'd': 3, 'e': 4}, {'c': 5, 'd': 6, 'e': 7}]}
+        self.db.collection.insert_one(doc)
+
+        result = self.db.collection.find_one({'a': 1}, {'a': 1, 'b': 1})
+        self.assertEqual(result, doc)
+
+        result = self.db.collection.find_one({'a': 1}, {'_id': 0, 'a': 1, 'b.c': 1, 'b.d': 1})
+        self.assertEqual(result, {'a': 1, 'b': [{'c': 2, 'd': 3}, {'c': 5, 'd': 6}]})
+
+        result = self.db.collection.find_one({'a': 1}, {'_id': 0, 'a': 0, 'b.c': 0, 'b.e': 0})
+        self.assertEqual(result, {'b': [{'d': 3}, {'d': 6}]})
+
+        # Test that a projection that does not fit the document does not result in an error
+        result = self.db.collection.find_one({'a': 1}, {'_id': 0, 'a': 1, 'b.c.f': 1})
+        self.assertEqual(result, {'a': 1, 'b': [{}, {}]})
+
+        result = self.db.collection.find_one({'a': 1}, {'_id': 0, 'a': 0, 'b.c': 0, 'b.c.f': 0})
+        self.assertEqual(result, {'b': [{'c': 2, 'd': 3, 'e': 4}, {'c': 5, 'd': 6, 'e': 7}]})
 
     def test__with_options(self):
         self.db.collection.with_options(read_preference=None)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -648,6 +648,16 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         # pymongo limit defaults to 0, returning everything
         self.cmp.compare.find(limit=0, sort=[("a", 1), ("b", -1)])
 
+    def test__find_projection_subdocument_lists(self):
+        self.cmp.do.remove()
+        self.cmp.do.insert({'a': 1, 'b': [{'c': 3, 'd': 4}, {'c': 5, 'd': 6}]})
+        for project in ({'_id': 0, 'a': 1, 'b': 1},
+                        {'_id': 0, 'a': 1, 'b.c': 1},
+                        {'_id': 0, 'a': 0, 'b.c': 0},
+                        {'_id': 0, 'a': 1, 'b.c.e': 1},
+                        {'_id': 0, 'a': 0, 'b.c': 0, 'b.c.e': 0}):
+            self.cmp.compare.find_one({'a': 1}, project)
+
     # def test__as_class(self):
     #     class MyDict(dict):
     #         pass


### PR DESCRIPTION
Make sure that when multiple fields of a subdocument are properly projected from an array as well.

Note:
Only after writing most of the code, I came across this pull-request:
https://github.com/mongomock/mongomock/pull/288, which is supposed to fix some, but not all of the issues I addressed.
I adapted the unit-tests that were added in that pull-request, as they were more comprehensive than mine. Hope that's ok.

This is another proposed fix for https://github.com/mongomock/mongomock/issues/287.