### PR TITLE
Add missing feature in map_reduce()

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -35,3 +35,4 @@ If i miss to include a feature in the below list, Please feel free to add to the
   * Text search operator ($meta)
   * Projection operators ($map, $let)
   * Array operators ($concatArrays, $filter, $isArray, $slice)
+* `map_reduce <https://docs.mongodb.com/manual/reference/command/mapReduce/>`_ options (``scope`` and ``finalize``)


### PR DESCRIPTION
The argument _scope_, for example, is very useful to add extra elements in the scope of the map and reduce functions.