### PR TITLE
Manage dictionaries in aggregate addToSet

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1766,7 +1766,7 @@ class Collection(object):
                                     elif operator == "$addToSet":
                                         doc_dict[field] = []
                                         val_it = (val or None for val in values)
-                                        # don't use set in case elt in not hashable (like dicts)
+                                        # Don't use set in case elt in not hashable (like dicts).
                                         for elt in val_it:
                                             if elt not in doc_dict[field]:
                                                 doc_dict[field].append(elt)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1771,7 +1771,6 @@ class Collection(object):
                                             if elt not in value:
                                                 value.append(elt)
                                         doc_dict[field] = value
-                                        doc_dict[field].reverse()
                                     elif operator == '$push':
                                         if field not in doc_dict:
                                             doc_dict[field] = []

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1764,8 +1764,13 @@ class Collection(object):
                                     elif operator == "$last":
                                         doc_dict[field] = values[-1]
                                     elif operator == "$addToSet":
+                                        doc_dict[field] = []
                                         val_it = (val or None for val in values)
-                                        doc_dict[field] = set(val_it)
+                                        # don't use set in case elt in not hashable (like dicts)
+                                        for elt in val_it:
+                                            if elt not in doc_dict[field]:
+                                                doc_dict[field].append(elt)
+                                        doc_dict[field].reverse()
                                     elif operator == '$push':
                                         if field not in doc_dict:
                                             doc_dict[field] = []

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1764,12 +1764,13 @@ class Collection(object):
                                     elif operator == "$last":
                                         doc_dict[field] = values[-1]
                                     elif operator == "$addToSet":
-                                        doc_dict[field] = []
+                                        value = []
                                         val_it = (val or None for val in values)
                                         # Don't use set in case elt in not hashable (like dicts).
                                         for elt in val_it:
-                                            if elt not in doc_dict[field]:
-                                                doc_dict[field].append(elt)
+                                            if elt not in value:
+                                                value.append(elt)
+                                        doc_dict[field] = value
                                         doc_dict[field].reverse()
                                     elif operator == '$push':
                                         if field not in doc_dict:

--- a/tests/test__diff.py
+++ b/tests/test__diff.py
@@ -1,4 +1,4 @@
-from .diff import diff
+from tests.diff import diff
 from unittest import TestCase
 
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1907,7 +1907,18 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         pipeline = [
             {'$group': {"_id": "$count", "set": {"$addToSet": {"a": "$a", "b": "$b"}}}},
         ]
-        self.cmp.compare_ignore_order.aggregate(pipeline)
+        # self.cmp.compare cannot be used as addToSet returns elements in an unpredictable order
+        aggregations = self.cmp.do.aggregate(pipeline)
+        expected = list(aggregations["real"])
+        result = list(aggregations["fake"])
+        self.assertEqual(len(result), len(expected))
+        set_expected = set([
+            tuple(sorted(e.items())) for elt in expected for e in elt['set']
+        ])
+        set_result = set([
+            tuple(sorted(e.items())) for elt in result for e in elt['set']
+        ])
+        self.assertEqual(set_result, set_expected)
 
 
 def _LIMIT(*args):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1895,8 +1895,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             {"a": {"c": "3", "d": 3}, "b": {"c": "4", "d": 4}, "nb": 1},
             {"a": {"c": "5", "d": 1}, "b": {"c": "6", "d": 6}, "nb": 2}
         ]
-        for item in data:
-            self.cmp.do.insert(item)
+        self.cmp.do.insert_many(data)
         pipeline = [
             {'$group': {"_id": "a.c", "nb": {"$addToSet": "b"}}},
         ]

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1891,9 +1891,10 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         # group addToSet dict element
         self.cmp.do.remove()
         data = [
-            {"a": {"c": "1", "d": 1}, "b": {"c": "2", "d": 2}, "nb": 1},
-            {"a": {"c": "3", "d": 3}, "b": {"c": "4", "d": 4}, "nb": 1},
-            {"a": {"c": "5", "d": 1}, "b": {"c": "6", "d": 6}, "nb": 2}
+            {"a": {"c": "1", "d": 1}, "b": {"c": "2", "d": 2}},
+            {"a": {"c": "1", "d": 3}, "b": {"c": "4", "d": 4}},
+            {"a": {"c": "5", "d": 1}, "b": {"c": "6", "d": 6}},
+            {"a": {"c": "5", "d": 2}, "b": {"c": "6", "d": 6}}
         ]
         self.cmp.do.insert_many(data)
         pipeline = [

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -11,7 +11,7 @@ from mongomock import Database
 from mongomock import InvalidURI
 from mongomock import OperationFailure
 
-from .utils import DBRef
+from tests.utils import DBRef
 
 try:
     from bson.objectid import ObjectId

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1878,13 +1878,13 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         aggregations = self.cmp.do.aggregate(pipeline)
         expected = list(aggregations["real"])
         result = list(aggregations["fake"])
-        assert len(result) == len(expected)
+        self.assertEqual(len(result), len(expected))
         for i, elt in enumerate(result):
             for k, v in elt.items():
                 if type(v) is list:
-                    assert set(v) == set(result[i][k])
+                    self.assertEqual(set(v), (result[i][k]))
                 else:
-                    assert v == result[i][k]
+                    self.assertEqual(v, result[i][k])
 
     def test__aggregate30(self):
         # group addToSet dict element

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1879,12 +1879,13 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         expected = list(aggregations["real"])
         result = list(aggregations["fake"])
         self.assertEqual(len(result), len(expected))
-        for i, elt in enumerate(result):
-            for k, v in elt.items():
-                if type(v) is list:
-                    self.assertEqual(set(v), (result[i][k]))
+        for expected_elt, result_elt in zip(expected, result):
+            self.assertEqual(expected_elt.keys(), result_elt.keys())
+            for key in result_elt:
+                if isinstance(result_elt[key], list):
+                    self.assertCountEqual(result_elt[key], expected_elt[key], msg=key)
                 else:
-                    self.assertEqual(v, result[i][k])
+                    self.assertEqual(result_elt[key], expected_elt[key], msg=key)
 
     def test__aggregate30(self):
         # group addToSet dict element


### PR DESCRIPTION
**What this PR does**  
This PR allows to use use $addToSet operator in aggregate on dictionaries.

**Example**

```
db.coll.aggregate([{"$group": {"_id": "$a", "set": {"$addToSet": "$dictionary"}}}])
```

**Notes**  
The corresponding tests have been added.  
I needed this functionality for my project, I hope you will find it usefull.

