### PR TITLE
Handle array size pipeline operator

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -33,4 +33,5 @@ If i miss to include a feature in the below list, Please feel free to add to the
   * Set operators ($setEquals, $setIntersection, $setDifference, …)
   * String operators ($concat, $strcasecmp, $substr, …)
   * Text search operator ($meta)
-  * Projection operators ($map, $let, $literal)
+  * Projection operators ($map, $let)
+  * Array operators ($concatArrays, $filter, $isArray, $slice)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1627,7 +1627,6 @@ class Collection(object):
             '$toUpper']
         text_search_operators = ['$meta']
         array_operators = [
-            '$arrayElemAt',
             '$concatArrays',
             '$filter',
             '$isArray',
@@ -1732,15 +1731,23 @@ class Collection(object):
                     "aggregation pipeline, it is currently not implemented "
                     " in Mongomock." % operator)
 
-        def _handle_array_operator(operator, values, doc_dict):
-            out_value = _parse_expression(values, doc_dict)
+        def _handle_array_operator(operator, value, doc_dict):
             if operator == '$size':
-                return len(out_value)
+                if isinstance(value, list):
+                    if len(value) != 1:
+                        raise OperationFailure("Expression $size takes exactly 1 arguments. "
+                                               "%d were passed in." % len(value))
+                    value = value[0]
+                array_value = _parse_expression(value, doc_dict)
+                if not isinstance(array_value, list):
+                    raise OperationFailure("The argument to $size must be an array, "
+                                           "but was of type: %s" % type(array_value))
+                return len(array_value)
             else:
                 raise NotImplementedError(
-                    "Although '%s' is a valid date operator for the "
+                    "Although '%s' is a valid array operator for the "
                     "aggregation pipeline, it is currently not implemented "
-                    " in Mongomock." % operator)
+                    "in Mongomock." % operator)
 
         def _handle_conditional_operator(operator, values, doc_dict):
             if operator == '$ifNull':
@@ -1789,6 +1796,14 @@ class Collection(object):
                                           "aggregation pipeline, it is currently not implemented "
                                           "in Mongomock." % operator)
 
+        def _handle_projection_operator(operator, value, doc_dict):
+            if operator == '$literal':
+                return value
+            else:
+                raise NotImplementedError("Although '%s' is a valid project operator for the "
+                                          "aggregation pipeline, it is currently not implemented "
+                                          "in Mongomock." % operator)
+
         def _parse_basic_expression(expression, doc_dict):
             if isinstance(expression, string_types) and expression.startswith('$'):
                 get_value = helpers.embedded_item_getter(expression.replace('$', ''))
@@ -1806,6 +1821,8 @@ class Collection(object):
                     return _handle_arithmetic_operator(k, v, doc_dict)
                 elif k in project_operators:
                     return _handle_project_operator(k, v, doc_dict)
+                elif k in projection_operators:
+                    return _handle_projection_operator(k, v, doc_dict)
                 elif k in comparison_operators:
                     return _handle_comparison_operator(k, v, doc_dict)
                 elif k in date_operators:


### PR DESCRIPTION
I needed to test using `$size` for a project. Implemented it here. 

I ran the following tests with PyMongo to confirm the $size behavior:

```
>>> col.insert({ '_id': '1', 'arr': [1,2,3] })
'1'

>>> list(col.aggregate([{'$project': {'s': {'$size': '$arr'}}}]))
[{'_id': '1', 's': 3}]

>>> list(col.aggregate([{'$project': {'s': {'$size': '$missing.missing'}}}]))
pymongo.errors.OperationFailure: The argument to $size must be an array, but was of type: missing

>>> list(col.aggregate([{'$project': {'s': {'$size': 'badstring'}}}]))
pymongo.errors.OperationFailure: The argument to $size must be an array, but was of type: string

>>> list(col.aggregate([{'$project': {'s': {'$size': [1,2,3]}}}]))
pymongo.errors.OperationFailure: Expression $size takes exactly 1 arguments. 3 were passed in.

>>> list(col.aggregate([{'$project': {'s': {'$size': [[1,2,3]]}}}]))
[{'_id': '1', 's': 3}]

>>> list(col.aggregate([{'$project': {'s': {'$size': ['$arr']}}}]))
[{'_id': '1', 's': 3}]

>>> list(col.aggregate([{'$project': {'s': {'$size': { '$literal': [1,2]}}}}]))
[{'_id': '1', 's': 2}]

>>> list(col.aggregate([{'$project': {'s': {'$size': [{ '$literal': [1,2]}]}}}]))
[{'_id': '1', 's': 2}]
```