### PR TITLE
Add few missing options/functions needed by pymodm 0.4.0

### DIFF
--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -49,7 +49,9 @@ class Database(object):
         return result
 
     def get_collection(self, name, codec_options=None, read_preference=None,
-                       write_concern=None):
+                       write_concern=None, read_concern=None):
+        if read_concern:
+            raise NotImplementedError('Mongomock does not handle read_concern yet')
         collection = self._collections.get(name)
         if collection is None:
             collection = self._collections[name] = \


### PR DESCRIPTION
collation and read_concern options are just added into the interfaces, without any implementation.
create_indexes is a simple loop wrapper over create_index.