### PR TITLE
implement support for the $rename operator

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -416,6 +416,11 @@ class Collection(object):
                     subdocument = self._update_document_fields_with_positional_awareness(
                         existing_document, v, spec, updater, subdocument)
 
+                elif k == '$rename':
+                    for src, dst in iteritems(v):
+                        if self._has_key(existing_document, src):
+                            existing_document[dst] = existing_document.pop(src)
+
                 elif k == '$setOnInsert':
                     if not was_insert:
                         continue

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -419,7 +419,10 @@ class Collection(object):
                 elif k == '$rename':
                     for src, dst in iteritems(v):
                         if '.' in src or '.' in dst:
-                            raise NotImplementedError('renaming with dots not supported yet')
+                            raise NotImplementedError(
+                                'Using the $rename operator with dots is a valid MongoDB '
+                                'operation, but it is not yet supported by mongomock'
+                            )
                         if self._has_key(existing_document, src):
                             existing_document[dst] = existing_document.pop(src)
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -418,6 +418,8 @@ class Collection(object):
 
                 elif k == '$rename':
                     for src, dst in iteritems(v):
+                        if '.' in src or '.' in dst:
+                            raise NotImplementedError('renaming with dots not supported yet')
                         if self._has_key(existing_document, src):
                             existing_document[dst] = existing_document.pop(src)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -464,6 +464,18 @@ class CollectionAPITest(TestCase):
         self.assertEqual(update_result.matched_count, 1)
         self.assert_document_stored(insert_result.inserted_id, {'a': 1, 'b': [{'d': 3}]})
 
+    def test__rename_one_foo_to_bar(self):
+        input_ = {'_id': 1, 'foo': 'bar'}
+        expected = {'_id': 1, 'bar': 'bar'}
+        insert_result = self.db.collection.insert_one(input_)
+        query = {'_id': 1}
+        update = {'$rename': {'foo': 'bar'}}
+        update_result = self.db.collection.update_one(query, update=update)
+
+        self.assertEqual(update_result.modified_count, 1)
+        self.assertEqual(update_result.matched_count, 1)
+        self.assert_document_stored(insert_result.inserted_id, expected)
+
     def test__update_one_upsert_invalid_filter(self):
         with self.assertRaises(mongomock.WriteError):
             self.db.collection.update_one(

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -476,6 +476,16 @@ class CollectionAPITest(TestCase):
         self.assertEqual(update_result.matched_count, 1)
         self.assert_document_stored(insert_result.inserted_id, expected)
 
+    def test__rename_unsupported(self):
+        input_ = {'_id': 1, 'foo': 'bar'}
+        insert_result = self.db.collection.insert_one(input_)
+        self.assert_document_stored(insert_result.inserted_id, input_)
+
+        query = {'_id': 1}
+        update = {'$rename': {'foo': 'f.o.o.'}}
+        self.assertRaises(NotImplementedError,
+                          self.db.collection.update_one, query, update=update)
+
     def test__update_one_upsert_invalid_filter(self):
         with self.assertRaises(mongomock.WriteError):
             self.db.collection.update_one(

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1269,6 +1269,17 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             except Exception as e:
                 assert isinstance(e, mongomock.OperationFailure)
 
+    def test__rename(self):
+        input_ = {'_id': 1, 'foo': 'bar'}
+        expected = {'_id': 1, 'bar': 'bar'}
+        insert_result = self.cmp.do.insert_one(input_)
+
+        query = {'_id': 1}
+        update = {'$rename': {'foo': 'bar'}}
+        update_result = self.cmp.do.update_one(query, update=update)
+
+        self.cmp.compare.find()
+
 
 @skipIf(not _HAVE_PYMONGO, "pymongo not installed")
 @skipIf(not _HAVE_MAP_REDUCE, "execjs not installed")

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1271,8 +1271,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__rename(self):
         input_ = {'_id': 1, 'foo': 'bar'}
-        expected = {'_id': 1, 'bar': 'bar'}
-        insert_result = self.cmp.do.insert_one(input_)
+        self.cmp.do.insert_one(input_)
 
         query = {'_id': 1}
         update = {'$rename': {'foo': 'bar'}}

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1275,7 +1275,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
         query = {'_id': 1}
         update = {'$rename': {'foo': 'bar'}}
-        update_result = self.cmp.do.update_one(query, update=update)
+        self.cmp.do.update_one(query, update=update)
 
         self.cmp.compare.find()
 


### PR DESCRIPTION
We need to support [this operation](https://docs.mongodb.com/manual/reference/operator/update/rename/).