### PR TITLE
fix travis tests broken due to 3.5, pypy issues due to dist: trusty switch 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ env:
   - TOX_ENV=py35-pyexecjs
   - TOX_ENV=pypy-pymongo
   - TOX_ENV=pypy-pyexecjs
-##  - TOX_ENV=pep8
 matrix:
-    # In order of most-valuable tests first
+    # Run all under 3.5 and pypy under pypy, temporary, to be rolled back once trusty fixes it
     include:
         - env: TOX_ENV=pypy-pymongo
           python: pypy-5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: true
 cache: pip
+python:
+  - 3.5
 env:
   - TOX_ENV=py27-pymongo
   - TOX_ENV=py27-pyexecjs
@@ -12,14 +14,26 @@ env:
   - TOX_ENV=py35-pyexecjs
   - TOX_ENV=pypy-pymongo
   - TOX_ENV=pypy-pyexecjs
-  - TOX_ENV=pep8
+##  - TOX_ENV=pep8
+matrix:
+    # In order of most-valuable tests first
+    include:
+        - env: TOX_ENV=pypy-pymongo
+          python: pypy-5.4.1
+        - env: TOX_ENV=pypy-pyexecjs
+          python: pypy-5.4.1
+    exclude:
+        - python: 3.5
+          env: TOX_ENV=pypy-pymongo
+        - python: 3.5
+          env: TOX_ENV=pypy-pyexecjs
+services:
+  - mongodb
 script:
   - tox -e $TOX_ENV
 before_install:
   - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
   - "sudo apt-get update"
-  - "sudo apt-get install mongodb-org-server"
 before_script:
   - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TOX_ENV=py35-pyexecjs
   - TOX_ENV=pypy-pymongo
   - TOX_ENV=pypy-pyexecjs
+  - TOX_ENV=pep8
 matrix:
     # Run all under 3.5 and pypy under pypy, temporary, to be rolled back once trusty fixes it
     include:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -255,15 +255,15 @@ class BulkOperationBuilder(object):
     def add_insert(self, doc):
         self.insert(doc)
 
-    def add_update(self, selector, doc, multi, upsert):
+    def add_update(self, selector, doc, multi, upsert, collation=None):
         write_operation = BulkWriteOperation(self, selector, is_upsert=upsert)
         write_operation.register_update_op(doc, multi)
 
-    def add_replace(self, selector, doc, upsert):
+    def add_replace(self, selector, doc, upsert, collation=None):
         write_operation = BulkWriteOperation(self, selector, is_upsert=upsert)
         write_operation.replace_one(doc)
 
-    def add_delete(self, selector, just_one):
+    def add_delete(self, selector, just_one, collation=None):
         write_operation = BulkWriteOperation(self, selector, is_upsert=False)
         write_operation.register_remove_op(not just_one)
 


### PR DESCRIPTION
Also changed mongodb as service as dist:trusty was not able to handle it right.
3.5 broken:
https://github.com/pytest-dev/pytest/issues/2779
pypy in trusty:
https://github.com/travis-ci/travis-ci/issues/6865
Changes to collection.py in pymongo, currently stubbed.
https://github.com/mongodb/mongo-python-driver/commit/8fdb581c6a6ba16678a67ec192972ad430bb6e67