### PR TITLE
Add a missing comma.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1275,7 +1275,7 @@ class Collection(object):
             '$sample'
             '$sort',
             '$geoNear',
-            '$lookup'
+            '$lookup',
             '$out',
             '$indexStats']
         group_operators = [


### PR DESCRIPTION
Was causing both $lookup and $out to appear as invalid MongoDB commands,
instead of not implemented.