### PR TITLE
Fix find and modify projection kwarg name

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -981,12 +981,12 @@ class Collection(object):
                                      sort, return_document, **kwargs)
 
     def find_and_modify(self, query={}, update=None, upsert=False, sort=None,
-                        full_response=False, manipulate=False, **kwargs):
+                        full_response=False, manipulate=False, fields=None, **kwargs):
         warnings.warn("find_and_modify is deprecated, use find_one_and_delete"
                       ", find_one_and_replace, or find_one_and_update instead",
                       DeprecationWarning, stacklevel=2)
         return self._find_and_modify(query, update=update, upsert=upsert,
-                                     sort=sort, **kwargs)
+                                     sort=sort, projection=fields, **kwargs)
 
     def _find_and_modify(self, query, projection=None, update=None,
                          upsert=False, sort=None,

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -985,6 +985,8 @@ class Collection(object):
         warnings.warn("find_and_modify is deprecated, use find_one_and_delete"
                       ", find_one_and_replace, or find_one_and_update instead",
                       DeprecationWarning, stacklevel=2)
+        if 'projection' in kwargs:
+            raise TypeError("find_and_modify() got an unexpected keyword argument 'projection'")
         return self._find_and_modify(query, update=update, upsert=upsert,
                                      sort=sort, projection=fields, **kwargs)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -308,6 +308,10 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(ValueError):  # this is also what pymongo raises
             self.db.collection.find_and_modify({"a": 2}, {"a": 3}, remove=True)
 
+    def test__find_and_modify_no_projection_kwarg(self):
+        with self.assertRaises(TypeError):  # unlike pymongo, we warn about this
+            self.db.collection.find_and_modify({"a": 2}, {"a": 3}, projection=['a'])
+
     def test__find_one_and_delete(self):
         documents = [
             {'x': 1, 's': 0},

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -574,8 +574,8 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find({'$nor': [{'x': 4}, {'x': 2}]})
 
     def test__find_and_modify_remove(self):
-        self.cmp.do.insert([{"a": x} for x in range(10)])
-        self.cmp.do.find_and_modify({"a": 2}, remove=True)
+        self.cmp.do.insert([{"a": x, "junk": True} for x in range(10)])
+        self.cmp.compare.find_and_modify({"a": 2}, remove=True, fields={'_id': False, 'a': True})
         self.cmp.compare_ignore_order.find()
 
     def test__find_one_and_delete(self):


### PR DESCRIPTION
Fixes https://github.com/mongomock/mongomock/issues/356

If the TypeError is overkill, it can be removed from the PR, but I think it's better to let people know if they use find_and_modify in a wrong way explictly, instead of strange bugs in code using mongomock the wrong way no longer respecting projection.