### PR TITLE
Fix behaviour of projection values in collection's find method.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -808,8 +808,9 @@ class Collection(object):
                     doc_copy = container()
                 else:
                     doc_copy = self._copy_field(doc, container)
-            # if 1 was passed in as the field values, include those fields
-            elif list(fields.values())[0] == 1:
+            # if a truthy value was passed in as the field values, include
+            # those fields
+            elif list(fields.values())[0]:
                 doc_copy = container()
                 for key in fields:
                     key_parts = key.split('.')

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -904,6 +904,29 @@ class CollectionAPITest(TestCase):
         expect = [{'_id': 1, 'list': [{"index": 1}, {"index": 2}]}]
         self.assertEqual(expect, list(actual))
 
+    def test__find_and_project(self):
+        self.db.collection.insert({'_id': 1, 'a': 42, 'b': 'other'})
+
+        self.assertEqual(
+            [{'_id': 1, 'a': 42}],
+            list(self.db.collection.find({}, projection={'a': 1})))
+        self.assertEqual(
+            [{'_id': 1, 'a': 42}],
+            list(self.db.collection.find({}, projection={'a': '1'})))
+        self.assertEqual(
+            [{'_id': 1, 'a': 42}],
+            list(self.db.collection.find({}, projection={'a': '0'})))
+        self.assertEqual(
+            [{'_id': 1, 'a': 42}],
+            list(self.db.collection.find({}, projection={'a': 'other'})))
+
+        self.assertEqual(
+            [{'_id': 1, 'b': 'other'}],
+            list(self.db.collection.find({}, projection={'a': 0})))
+        self.assertEqual(
+            [{'_id': 1, 'b': 'other'}],
+            list(self.db.collection.find({}, projection={'a': False})))
+
     def test__with_options(self):
         self.db.collection.with_options(read_preference=None)
 


### PR DESCRIPTION
This avoids confusion for users who might use
```py
db.collection.find({}, {
  'myField': '1',
})
```

See the use of `'1'` instead of `1`: the mongomock library would have handled `'1'` as `0` in that case!