### PR TITLE
Fixes #364. Support no-argument get_database() semantics

### DIFF
--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -81,8 +81,11 @@ class MongoClient(object):
             db = self._databases[name_or_db]
             drop_collections_for_db(db)
 
-    def get_database(self, name, codec_options=None, read_preference=None,
+    def get_database(self, name=None, codec_options=None, read_preference=None,
                      write_concern=None):
+        if name is None:
+            return self.get_default_database()
+
         db = self._databases.get(name)
         if db is None:
             db = self._databases[name] = Database(self, name)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -159,6 +159,11 @@ class DatabaseGettingTest(TestCase):
         c, db = gddb(['mongodb://localhost:27017/foo', 'mongodb://localhost:27018/foo'])
         self.assertIs(db, c['foo'])
 
+        # As of pymongo 3.5, get_database() is equivalent to
+        # the old behavior of get_default_database()
+        client = mongomock.MongoClient('mongodb://host1/foo')
+        self.assertIs(client.get_database(), client['foo'])
+
     def test__getting_default_database_invalid(self):
         def client(uri):
             return mongomock.MongoClient(uri)


### PR DESCRIPTION
@vmalloc this allows our downstream project https://github.com/girder/girder to use mongomock in our testing again. If you need someone to help maintain this project, I'm happy to review and merge important PRs and publish pypi packages if you are willing to grant access.