### PR TITLE
Make distinct() works with list of nested fields

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -49,6 +49,7 @@ from six import text_type
 from mongomock import aggregate
 from mongomock import ConfigurationError, DuplicateKeyError, BulkWriteError
 from mongomock.filtering import filter_applies
+from mongomock.filtering import iter_key_candidates
 from mongomock.filtering import resolve_key
 from mongomock.filtering import resolve_sort_key
 from mongomock import helpers
@@ -1706,17 +1707,17 @@ class Cursor(object):
         unique = set()
         unique_dict_vals = []
         for x in self._compute_results():
-            value = resolve_key(key, x)
-            if value == NOTHING:
-                continue
-            if isinstance(value, dict):
-                if any(dict_val == value for dict_val in unique_dict_vals):
+            for value in iter_key_candidates(key, x):
+                if value == NOTHING:
                     continue
-                unique_dict_vals.append(value)
-            else:
-                unique.update(
-                    value if isinstance(
-                        value, (tuple, list)) else [value])
+                if isinstance(value, dict):
+                    if any(dict_val == value for dict_val in unique_dict_vals):
+                        continue
+                    unique_dict_vals.append(value)
+                else:
+                    unique.update(
+                        value if isinstance(
+                            value, (tuple, list)) else [value])
         return list(unique) + unique_dict_vals
 
     def __getitem__(self, index):

--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -35,12 +35,12 @@ def filter_applies(search_filter, document):
             not isinstance(search, dict) or (set(search.keys()) - {'$ne', '$nin'})
         has_candidates = False
 
-        if search == {'$exists': False} and not _iter_key_candidates(key, document):
+        if search == {'$exists': False} and not iter_key_candidates(key, document):
             continue
         if key == '$comment':
             continue
 
-        for doc_val in _iter_key_candidates(key, document):
+        for doc_val in iter_key_candidates(key, document):
             has_candidates |= doc_val is not NOTHING
             if isinstance(search, dict):
                 if '$options' in search and '$regex' in search:
@@ -81,7 +81,7 @@ def filter_applies(search_filter, document):
     return True
 
 
-def _iter_key_candidates(key, doc):
+def iter_key_candidates(key, doc):
     """Get possible subdocuments or lists that are referred to by the key in question
 
     Returns the appropriate nested value if the key includes dot notation.
@@ -104,7 +104,7 @@ def _iter_key_candidates(key, doc):
 
     sub_key = '.'.join(key_parts[1:])
     sub_doc = doc.get(key_parts[0], {})
-    return _iter_key_candidates(sub_key, sub_doc)
+    return iter_key_candidates(sub_key, sub_doc)
 
 
 def _iter_key_candidates_sublist(key, doc):
@@ -126,14 +126,14 @@ def _iter_key_candidates_sublist(key, doc):
         return [x
                 for sub_doc in doc
                 if isinstance(sub_doc, dict) and sub_key in sub_doc
-                for x in _iter_key_candidates(key_remainder, sub_doc[sub_key])]
+                for x in iter_key_candidates(key_remainder, sub_doc[sub_key])]
 
     # subkey is an index
     if sub_key_int >= len(doc):
         return ()  # dead end
     sub_doc = doc[sub_key_int]
     if key_parts:
-        return _iter_key_candidates('.'.join(key_parts), sub_doc)
+        return iter_key_candidates('.'.join(key_parts), sub_doc)
     return [sub_doc]
 
 
@@ -366,7 +366,7 @@ TYPE_MAP = {
 
 
 def resolve_key(key, doc):
-    return next(iter(_iter_key_candidates(key, doc)), NOTHING)
+    return next(iter(iter_key_candidates(key, doc)), NOTHING)
 
 
 def resolve_sort_key(key, doc):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -181,8 +181,16 @@ class CollectionAPITest(TestCase):
         cursor = self.db.collection.find()
         self.assertEqual(set(cursor.distinct('f1')), set(['v1', 'v2', 'v3']))
 
+    def test__distinct_array_nested_field(self):
+        self.db.collection.insert({'f1': [{'f2': 'v'}, {'f2': 'w'}]})
+        cursor = self.db.collection.find()
+        self.assertEqual(set(cursor.distinct('f1.f2')), {'v', 'w'})
+
     def test__distinct_document_field(self):
-        self.db.collection.insert({'f1': {'f2': 'v2', 'f3': 'v3'}})
+        self.db.collection.insert_many([
+            {'f1': {'f2': 'v2', 'f3': 'v3'}},
+            {'f1': {'f2': 'v2', 'f3': 'v3'}}
+        ])
         cursor = self.db.collection.find()
         self.assertEqual(cursor.distinct('f1'), [{'f2': 'v2', 'f3': 'v3'}])
 
@@ -190,6 +198,10 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert([{'f1': 'v1', 'k1': 'v1'}, {'f1': 'v2', 'k1': 'v1'},
                                    {'f1': 'v3', 'k1': 'v2'}])
         self.assertEqual(set(self.db.collection.distinct('f1', {'k1': 'v1'})), set(['v1', 'v2']))
+
+    def test__distinct_error(self):
+        with self.assertRaises(TypeError):
+            self.db.collection.distinct({'f1': 1})
 
     def test__cursor_clone(self):
         self.db.collection.insert([{'a': 'b'}, {'b': 'c'}, {'c': 'd'}])


### PR DESCRIPTION
Currently, calling distinct on a field that is a list of subdocuments only resolve distinct items of the first document.
Try to iterate through all of the values and correctly return the proper expected result.

This commit passes the tests (from what I can tell as some are failing on master branch) and works for my use case, but I would be interested in getting comments/critics from other people.