### PR TITLE
Add support to tz_aware=True option

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1767,7 +1767,11 @@ class Cursor(object):
     def _compute_results(self, with_limit_and_skip=False):
         # Recompute the result only if the query has changed
         if not self._results or self._factory_last_generated_results != self._factory:
-            results = list(self._factory())
+            if self.collection.database.client._tz_aware:
+                results = [helpers.make_datetime_timezone_aware_in_document(x)
+                           for x in self._factory()]
+            else:
+                results = list(self._factory())
             self._factory_last_generated_results = self._factory
             self._results = results
         if with_limit_and_skip:

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -7,8 +7,8 @@ import warnings
 
 
 try:
-    from bson import (ObjectId, RE_TYPE)
-    from bson.tz_util import utc
+    from bson import (ObjectId, RE_TYPE, tz_util)
+    utc = tz_util.utc
 except ImportError:
     from mongomock.object_id import ObjectId  # noqa
     RE_TYPE = re._pattern_type

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, tzinfo
 from mongomock import InvalidURI
 import re
 from six.moves.urllib_parse import unquote_plus
@@ -8,9 +8,33 @@ import warnings
 
 try:
     from bson import (ObjectId, RE_TYPE)
+    from bson.tz_util import utc
 except ImportError:
     from mongomock.object_id import ObjectId  # noqa
     RE_TYPE = re._pattern_type
+
+    class FixedOffset(tzinfo):
+
+        def __init__(self, offset, name):
+            if isinstance(offset, timedelta):
+                self.__offset = offset
+            else:
+                self.__offset = timedelta(minutes=offset)
+            self.__name = name
+
+        def __getinitargs__(self):
+            return self.__offset, self.__name
+
+        def utcoffset(self, dt):
+            return self.__offset
+
+        def tzname(self, dt):
+            return self.__name
+
+        def dst(self, dt):
+            return timedelta(0)
+    utc = FixedOffset(0, "UTC")
+
 
 # for Python 3 compatibility
 if PY2:
@@ -237,5 +261,19 @@ def patch_datetime_awareness_in_document(value):
         return [patch_datetime_awareness_in_document(item) for item in value]
     elif isinstance(value, datetime) and value.tzinfo:
         return (value - value.utcoffset()).replace(tzinfo=None)
+    else:
+        return value
+
+
+def make_datetime_timezone_aware_in_document(value):
+    # MongoClient support tz_aware=True parameter to return timezone-aware
+    # datetime objects. Given the date is stored internally without timezone
+    # information, all returned datetime have utc as timezone.
+    if isinstance(value, dict):
+        return {k: make_datetime_timezone_aware_in_document(v) for k, v in value.items()}
+    elif isinstance(value, (tuple, list)):
+        return [make_datetime_timezone_aware_in_document(item) for item in value]
+    elif isinstance(value, datetime):
+        return value.replace(tzinfo=utc)
     else:
         return value

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -7,12 +7,18 @@ import warnings
 
 
 try:
-    from bson import (ObjectId, RE_TYPE, tz_util)
-    utc = tz_util.utc
+    from bson import ObjectId
 except ImportError:
     from mongomock.object_id import ObjectId  # noqa
+
+try:
+    from bson import RE_TYPE
+except ImportError:
     RE_TYPE = re._pattern_type
 
+try:
+    from bson.tz_util import utc
+except ImportError:
     class FixedOffset(tzinfo):
 
         def __init__(self, offset, name):

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -17,6 +17,7 @@ class MongoClient(object):
         else:
             self.host = self.HOST
         self.port = port or self.PORT
+        self._tz_aware = tz_aware
         self._databases = {}
         self._id = next(self._CONNECTION_ID)
         self._document_class = document_class


### PR DESCRIPTION
Currently only tz naive dates are returned by mongomock, this patch allow to return tz aware datetime