### PR TITLE
Basic pyMODM compatibility

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -303,11 +303,11 @@ class Collection(object):
         validate_write_concern_params(**kwargs)
         return self._insert(data)
 
-    def insert_one(self, document):
+    def insert_one(self, document, **kwargs):
         validate_is_mutable_mapping('document', document)
         return InsertOneResult(self._insert(document), acknowledged=True)
 
-    def insert_many(self, documents, ordered=True):
+    def insert_many(self, documents, ordered=True, **kwargs):
         if not isinstance(documents, collections.Iterable) or not documents:
             raise TypeError('documents must be a non-empty list')
         for document in documents:
@@ -370,18 +370,18 @@ class Collection(object):
             sub_doc = sub_doc[part]
         del sub_doc[key_parts[-1]]
 
-    def update_one(self, filter, update, upsert=False):
+    def update_one(self, filter, update, upsert=False, **kwargs):
         validate_ok_for_update(update)
         return UpdateResult(self._update(filter, update, upsert=upsert),
                             acknowledged=True)
 
-    def update_many(self, filter, update, upsert=False):
+    def update_many(self, filter, update, upsert=False, **kwargs):
         validate_ok_for_update(update)
         return UpdateResult(self._update(filter, update, upsert=upsert,
                                          multi=True),
                             acknowledged=True)
 
-    def replace_one(self, filter, replacement, upsert=False):
+    def replace_one(self, filter, replacement, upsert=False, **kwargs):
         validate_ok_for_replace(replacement)
         return UpdateResult(self._update(filter, replacement, upsert=upsert),
                             acknowledged=True)
@@ -1065,11 +1065,11 @@ class Collection(object):
                          manipulate, check_keys=True, **kwargs)
             return to_save.get("_id", None)
 
-    def delete_one(self, filter):
+    def delete_one(self, filter, **kwargs):
         validate_is_mapping('filter', filter)
         return DeleteResult(self._delete(filter), True)
 
-    def delete_many(self, filter):
+    def delete_many(self, filter, **kwargs):
         validate_is_mapping('filter', filter)
         return DeleteResult(self._delete(filter, multi=True), True)
 


### PR DESCRIPTION
This is a simple pull request for #382 which is focused on making mongomock compatible with pyMODM. This should address all immediate compatibility issues and allow for basic functionality with these two libraries.

As I continue to use mongomock and pyMODM together, I am bound to find more bugs. If the maintainers are comfortable with the following plan, I would like to tackle these discrepancies with their own pull requests as they come up.

Before moving forward with this, I believe the question of testing should be addressed. It would be possible to build a test suite within this library that tests mongomock against pyMODM. However, I assume that this is outside the scope and responsibility that this library wants to hold.