### PR TITLE
Unit test that {x: {$in: [None,...]}} matches when {x: {$exists: False}}

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -586,9 +586,11 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.insert([
             dict(x=single),
             dict(x=even),
-            dict(x=prime)])
+            dict(x=prime),
+            dict()])
         self.cmp.compare_ignore_order.find({'x': {'$in': [7, 8]}})
         self.cmp.compare_ignore_order.find({'x': {'$in': [4, 5]}})
+        self.cmp.compare_ignore_order.find({'x': {'$in': [4, None]}})
         self.cmp.compare_ignore_order.find({'x': {'$nin': [2, 5]}})
         self.cmp.compare_ignore_order.find({'x': {'$all': [2, 5]}})
         self.cmp.compare_ignore_order.find({'x': {'$all': [7, 8]}})


### PR DESCRIPTION
`{x: {$in: [None,...]}}` should match both when x is `None`, when x is an array with `None` in it, *and* when x is not present. This PR tests for that. I have a separate PR for the fix, as you said should be done in a comment in #382.