### PR TITLE
Fix nested field unique index in insert

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -379,22 +379,6 @@ class Collection(object):
     def _internalize_dict(self, d):
         return {k: copy.deepcopy(v) for k, v in iteritems(d)}
 
-    def _has_key(self, doc, key):
-        key_parts = key.split('.')
-        sub_doc = doc
-        for part in key_parts:
-            if part not in sub_doc:
-                return False
-            sub_doc = sub_doc[part]
-        return True
-
-    def _remove_key(self, doc, key):
-        key_parts = key.split('.')
-        sub_doc = doc
-        for part in key_parts[:-1]:
-            sub_doc = sub_doc[part]
-        del sub_doc[key_parts[-1]]
-
     def update_one(self, filter, update, upsert=False):
         validate_ok_for_update(update)
         return UpdateResult(self._update(filter, update, upsert=upsert),

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -365,7 +365,10 @@ class Collection(object):
         for unique, is_sparse in self._uniques:
             find_kwargs = {}
             for key, direction in unique:
-                find_kwargs[key] = data.get(key, None)
+                try:
+                    find_kwargs[key] = get_value_by_dot(data, key)
+                except KeyError:
+                    find_kwargs[key] = None
             answer_count = len(list(self._iter_documents(find_kwargs)))
             if answer_count > 0 and not (is_sparse and find_kwargs[key] is None):
                 raise DuplicateKeyError("E11000 Duplicate Key Error", 11000)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -95,20 +95,41 @@ def validate_write_concern_params(**params):
 def get_value_by_dot(doc, key):
     """Get dictionary value using dotted key"""
     result = doc
-    for i in key.split('.'):
-        result = result[i]
+    for key_item in key.split('.'):
+        if isinstance(result, dict):
+            result = result[key_item]
+
+        elif isinstance(result, (list, tuple)):
+            try:
+                result = result[int(key_item)]
+            except (ValueError, IndexError):
+                raise KeyError()
+
+        else:
+            raise KeyError()
+
     return result
 
 
 def set_value_by_dot(doc, key, value):
     """Set dictionary value using dotted key"""
-    result = doc
-    keys = key.split('.')
-    for i in keys[:-1]:
-        if i not in result:
-            result[i] = {}
-        result = result[i]
-    result[keys[-1]] = value
+    try:
+        parent_key, child_key = key.rsplit('.', 1)
+        parent = get_value_by_dot(doc, parent_key)
+    except ValueError:
+        child_key = key
+        parent = doc
+
+    if isinstance(parent, dict):
+        parent[child_key] = value
+    elif isinstance(parent, (list, tuple)):
+        try:
+            parent[int(child_key)] = value
+        except (ValueError, IndexError):
+            raise KeyError()
+    else:
+        raise KeyError()
+
     return doc
 
 

--- a/tests/test__collection.py
+++ b/tests/test__collection.py
@@ -1,0 +1,50 @@
+from mongomock.collection import get_value_by_dot, set_value_by_dot
+from unittest import TestCase
+
+
+class CollectionTest(TestCase):
+
+    def test__get_value_by_dot_missing_key(self):
+        """Test get_value_by_dot raises KeyError when looking for a missing key"""
+        for doc, key in (
+                ({}, 'a'),
+                ({'a': 1}, 'b'),
+                ({'a': 1}, 'a.b'),
+                ({'a': {'b': 1}}, 'a.b.c'),
+                ({'a': {'b': 1}}, 'a.c'),
+                ({'a': [{'b': 1}]}, 'a.b'),
+                ({'a': [{'b': 1}]}, 'a.1.b')):
+            self.assertRaises(KeyError, get_value_by_dot, doc, key)
+
+    def test__get_value_by_dot_find_key(self):
+        """Test get_value_by_dot when key can be found"""
+        for doc, key, expected in (
+                ({'a': 1}, 'a', 1),
+                ({'a': {'b': 1}}, 'a', {'b': 1}),
+                ({'a': {'b': 1}}, 'a.b', 1),
+                ({'a': [{'b': 1}]}, 'a.0.b', 1)):
+            found = get_value_by_dot(doc, key)
+            self.assertEqual(found, expected)
+
+    def test__set_value_by_dot(self):
+        """Test set_value_by_dot"""
+        for doc, key, expected in (
+                ({}, 'a', {'a': 42}),
+                ({'a': 1}, 'a', {'a': 42}),
+                ({'a': {'b': 1}}, 'a', {'a': 42}),
+                ({'a': {'b': 1}}, 'a.b', {'a': {'b': 42}}),
+                ({'a': [{'b': 1}]}, 'a.0', {'a': [42]}),
+                ({'a': [{'b': 1}]}, 'a.0.b', {'a': [{'b': 42}]})):
+            ret = set_value_by_dot(doc, key, 42)
+            assert ret is doc
+            self.assertEqual(ret, expected)
+
+    def test__set_value_by_dot_bad_key(self):
+        """Test set_value_by_dot when key has an invalid parent"""
+        for doc, key in (
+                ({}, 'a.b'),
+                ({'a': 1}, 'a.b'),
+                ({'a': {'b': 1}}, 'a.b.c'),
+                ({'a': [{'b': 1}]}, 'a.1.b'),
+                ({'a': [{'b': 1}]}, 'a.1')):
+            self.assertRaises(KeyError, set_value_by_dot, doc, key, 42)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands= nosetests -x -s {posargs}
 
 [testenv:pep8]
 basepython = python2
-deps = hacking>=0.9.3
+deps = hacking==1.0.0
 commands = flake8 {posargs}
 
 [flake8]


### PR DESCRIPTION
Currently nested unique index are not handled properly, to reproduce the error:
```python
cl = mongomock.MongoClient()
col = cl.foo.foo

col.create_index('a.b', unique=True)
col.insert({'a': {'b': 1}})
col.insert({'a': {'b': 1}})  # Doesn't raise DuplicateKeyError
```

btw @vmalloc  could it be possible to get commit rights on the repo ? I'm now pretty confident with the codebase (see [my PR history on the project](https://github.com/mongomock/mongomock/pulls?q=is%3Apr+author%3AtouilleMan+is%3Aclosed))
From my point of view anybody with a couple of PRs merged should be granted with this right, this is a really good way to keep the project alive and from my personal experience, people are always very respectful and willing to follow the guidelines when put in this position.