### PR TITLE
Update Missing_Features.rst

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -8,3 +8,4 @@ If i miss to include a feature in the below list, Please feel free to add to the
 * create_collection options - https://docs.mongodb.com/v3.2/reference/method/db.createCollection/#definition
 * bypass_document_validation options
 * session options
+* $multiply operator - https://docs.mongodb.com/manual/reference/operator/aggregation/multiply/


### PR DESCRIPTION
Getting error "NotImplementedError: Although '$multiply' is a valid aritmetic operator for the aggregation pipeline, it is currently not implemented  in Mongomock." when using $multiply in aggregation pipelines in my tests :(