### PR TITLE
 fix(re): fix error in python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ python:
 env:
   - TOX_ENV=py27-pymongo
   - TOX_ENV=py27-pyexecjs
-  - TOX_ENV=py33-pymongo
-  - TOX_ENV=py33-pyexecjs
   - TOX_ENV=py34-pymongo
   - TOX_ENV=py34-pyexecjs
   - TOX_ENV=py35-pymongo
   - TOX_ENV=py35-pyexecjs
+  - TOX_ENV=py36-pymongo
+  - TOX_ENV=py36-pyexecjs
+  - TOX_ENV=py37-pymongo
+  - TOX_ENV=py37-pyexecjs
   - TOX_ENV=pypy-pymongo
   - TOX_ENV=pypy-pyexecjs
   - TOX_ENV=pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,29 @@ matrix:
           python: pypy-5.4.1
         - env: TOX_ENV=pypy-pyexecjs
           python: pypy-5.4.1
+        - env: TOX_ENV=py36-pymongo
+          python: 3.6
+        - env: TOX_ENV=py36-pyexecjs
+          python: 3.6
+        - env: TOX_ENV=py37-pymongo
+          python: 3.7
+          dist: xenial
+        - env: TOX_ENV=py37-pyexecjs
+          python: 3.7
+          dist: xenial
     exclude:
         - python: 3.5
           env: TOX_ENV=pypy-pymongo
         - python: 3.5
           env: TOX_ENV=pypy-pyexecjs
+        - python: 3.5
+          env: TOX_ENV=py36-pymongo
+        - python: 3.5
+          env: TOX_ENV=py36-pyexecjs
+        - python: 3.5
+          env: TOX_ENV=py37-pymongo
+        - python: 3.5
+          env: TOX_ENV=py37-pyexecjs
 services:
   - mongodb
 script:

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -15,7 +15,7 @@ except ImportError:
 try:
     from bson import RE_TYPE
 except ImportError:
-    if sys.version_info > (3, 7):
+    if sys.version_info >= (3, 7):
         # for python3.7+
         RE_TYPE = re.Pattern
     else:

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -15,7 +15,7 @@ except ImportError:
 try:
     from bson import RE_TYPE
 except ImportError:
-    if sys.version_info[0] > 2 and sys.version_info[1] > 6:
+    if sys.version_info > (3, 7):
         # for python3.7+
         RE_TYPE = re.Pattern
     else:

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -3,6 +3,7 @@ from mongomock import InvalidURI
 import re
 from six.moves.urllib_parse import unquote_plus
 from six import iteritems, PY2
+import sys
 import warnings
 
 
@@ -14,7 +15,11 @@ except ImportError:
 try:
     from bson import RE_TYPE
 except ImportError:
-    RE_TYPE = re._pattern_type
+    if sys.version_info[0] > 2 and sys.version_info[1] > 6:
+        # for python3.7+
+        RE_TYPE = re.Pattern
+    else:
+        RE_TYPE = re._pattern_type
 
 try:
     from bson.tz_util import utc

--- a/tests/multicollection.py
+++ b/tests/multicollection.py
@@ -1,7 +1,7 @@
 from .diff import diff
 import copy
 import functools
-import re
+from mongomock.helpers import RE_TYPE
 
 
 class MultiCollection(object):
@@ -131,7 +131,7 @@ def _format_diff_message(a_name, b_name, diff):
 
 def _deepcopy(x):
     """Deepcopy, but ignore regex objects..."""
-    if isinstance(x, re._pattern_type):
+    if isinstance(x, RE_TYPE):
         return x
     if isinstance(x, list) or isinstance(x, tuple):
         return type(x)(_deepcopy(y) for y in x)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = pep8,{py27,py33,py34,py35,pypy}-{pymongo,pyexecjs}
+envlist = pep8,{py27,py34,py35,py36,py37,pypy}-{pymongo,pyexecjs}
 
 [testenv]
 basepython =
     py27: python2.7
-    py33: python3.4
     py34: python3.4
     py35: python3.5
+    py36: python3.6
+    py37: python3.7
     pypy: pypy
 deps=
     nose


### PR DESCRIPTION
Hi there.
Python 3.7 removes `re._pattern_type` and renames it to `re.Pattern`.
https://github.com/python/cpython/pull/1646
I also remove test for py3.3(point to python3.4, which is redudant) and add test for py3.6 & 3.7. :)