### PR TITLE
Add missing arguments to `Collection.bulk_write()`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,7 @@ Also, many thanks go to the following people for helping out, contributing pull 
 * David Fischer
 * Diego Garcia
 * Dmitriy Kostochko
+* Drew Winstel
 * Edward D'Souza
 * Emily Rosengren
 * Eugene Chernyshov

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1788,7 +1788,7 @@ class Collection(object):
     def rename(self, new_name, **kwargs):
         self.database.rename_collection(self.name, new_name, **kwargs)
 
-    def bulk_write(self, operations):
+    def bulk_write(self, operations, ordered=True, bypass_document_validation=False, session=None):
         bulk = BulkOperationBuilder(self)
         for operation in operations:
             operation._add_to_bulk(bulk)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1788,9 +1788,9 @@ class Collection(object):
     def rename(self, new_name, **kwargs):
         self.database.rename_collection(self.name, new_name, **kwargs)
 
-    def bulk_write(self, operations, ordered=True, bypass_document_validation=False, session=None):
+    def bulk_write(self, requests, ordered=True, bypass_document_validation=False, session=None):
         bulk = BulkOperationBuilder(self)
-        for operation in operations:
+        for operation in requests:
             operation._add_to_bulk(bulk)
         return BulkWriteResult(bulk.execute(), True)
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1789,6 +1789,18 @@ class Collection(object):
         self.database.rename_collection(self.name, new_name, **kwargs)
 
     def bulk_write(self, requests, ordered=True, bypass_document_validation=False, session=None):
+        if not ordered:
+            raise NotImplementedError(
+                'Unordered mode is a valid MongoDB operation; however Mongomock'
+                ' does not support it yet.')
+        if bypass_document_validation:
+            raise NotImplementedError(
+                'Skipping document validation is a valid MongoDB operation;'
+                ' however Mongomock does not support it yet.')
+        if session:
+            raise NotImplementedError(
+                'Sessions are valid in MongoDB 3.6 and newer; however Mongomock'
+                ' does not support them yet.')
         bulk = BulkOperationBuilder(self)
         for operation in requests:
             operation._add_to_bulk(bulk)


### PR DESCRIPTION
Bring the method signature up to par with pymongo's:

- Add `ordered`, `bypass_document_validation`, and `session`
- Rename `operations` to `requests`

Fixes #389.