### PR TITLE
Properly raise InvalidDocument exception when trying to update or rep…

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -689,6 +689,9 @@ class Collection(object):
                         existing_document.clear()
                         if _id:
                             existing_document['_id'] = _id
+                        if BSON:
+                            # bson validation
+                            BSON.encode(document, check_keys=True)
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             raise OperationFailure(
@@ -2004,6 +2007,9 @@ def _set_updater(doc, field_name, value):
     if isinstance(value, (tuple, list)):
         value = copy.deepcopy(value)
     if isinstance(doc, dict):
+        if BSON:
+            # bson validation
+            BSON.encode({field_name: value}, check_keys=True)
         doc[field_name] = value
 
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1723,6 +1723,20 @@ class CollectionAPITest(TestCase):
             collection.insert({"$foo": "bar"})
         self.assertEqual(str(cm.exception), "key '$foo' must not start with '$'")
 
+    @skipIf(not _HAVE_PYMONGO, "pymongo not installed")
+    def test__update_invalid_encode_type(self):
+        self.db.collection.insert_one({'_id': 1, 'foo': 'bar'})
+
+        with self.assertRaises(InvalidDocument):
+            self.db.collection.update_one({}, {'$set': {'foo': {'bar'}}})
+
+    @skipIf(not _HAVE_PYMONGO, "pymongo not installed")
+    def test__replace_invalid_encode_type(self):
+        self.db.collection.insert_one({'_id': 1, 'foo': 'bar'})
+
+        with self.assertRaises(InvalidDocument):
+            self.db.collection.replace_one({}, {'foo': {'bar'}})
+
     def test_aggregate_unwind_push_first(self):
         collection = self.db.collection
         collection.insert_many(


### PR DESCRIPTION
…lace a document with an invalid type (e.g. a Python set).