### PR TITLE
handling multiple fields inside "only" operation using the same prefix.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -806,7 +806,6 @@ class Collection(object):
         return Cursor(self, spec, sort, projection, skip, limit, collation=collation)
 
     def _get_dataset(self, spec, sort, fields, as_class):
-        print "sagy - _get_dataset = %r , %r , %r" % (spec, fields, as_class)
         dataset = (self._copy_only_fields(document, fields, as_class)
                    for document in self._iter_documents(spec))
         if sort:
@@ -877,7 +876,6 @@ class Collection(object):
 
     def _copy_only_fields(self, doc, fields, container):
         """Copy only the specified fields."""
-        print "inside _copy_only_fields: %r , %r" % (fields, container)
 
         if fields is None:
             return self._copy_field(doc, container)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -806,6 +806,7 @@ class Collection(object):
         return Cursor(self, spec, sort, projection, skip, limit, collation=collation)
 
     def _get_dataset(self, spec, sort, fields, as_class):
+        print "sagy - _get_dataset = %r , %r , %r" % (spec, fields, as_class)
         dataset = (self._copy_only_fields(document, fields, as_class)
                    for document in self._iter_documents(spec))
         if sort:
@@ -876,6 +877,7 @@ class Collection(object):
 
     def _copy_only_fields(self, doc, fields, container):
         """Copy only the specified fields."""
+        print "inside _copy_only_fields: %r , %r" % (fields, container)
 
         if fields is None:
             return self._copy_field(doc, container)
@@ -931,9 +933,10 @@ class Collection(object):
                                            for x in subdocument if last_key in x]
                             if subdocument:
                                 if last_copy.get(key_parts[-2]):
-                                    # key_parts[-2] was already used - needed when only-fields are used on the same
-                                    # dict. e.g. Book.objects().only('book.name', 'book.length')
-                                    last_copy[key_parts[-2]][0].update(subdocument[0])
+                                    # key_parts[-2] was already used as field's prefix in the projection parameter
+                                    # e.g. 'book_data' in: db.book.find({}, {book_data.name:1, book_data.length:1})
+                                    for last_copy_index in range(len(last_copy[key_parts[-2]])):
+                                        last_copy[key_parts[-2]][last_copy_index].update(subdocument[last_copy_index])
                                 else:
                                     last_copy[key_parts[-2]] = subdocument
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -930,7 +930,13 @@ class Collection(object):
                             subdocument = [{last_key: x[last_key]}
                                            for x in subdocument if last_key in x]
                             if subdocument:
-                                last_copy[key_parts[-2]] = subdocument
+                                if last_copy.get(key_parts[-2]):
+                                    # key_parts[-2] was already used - needed when only-fields are used on the same
+                                    # dict. e.g. Book.objects().only('book.name', 'book.length')
+                                    last_copy[key_parts[-2]][0].update(subdocument[0])
+                                else:
+                                    last_copy[key_parts[-2]] = subdocument
+
             # otherwise, exclude the fields passed in
             else:
                 doc_copy = self._copy_field(doc, container)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1964,6 +1964,13 @@ class MongoClientSortSkipLimitTest(_CollectionComparisonTest):
         # Does nothing - just make sure it exists and takes the right args
         self.cmp.do(lambda cursor: cursor.close()).find()
 
+    def test__multiple_projection_values(self):
+        self.cmp.do.remove()
+        data = {"book_id": 123, "book_translations": [{"translator": 'Sagy', "language": 'Hebrew'},
+                                                      {"translator": 'Yuri', "language": 'Russian'}]}
+        self.cmp.do.insert(data)
+        self.cmp.compare.find({"book_id": 123}, {"book_translations.translator": 1, "book_translations.language": 1})
+
 
 class InsertedDocumentTest(TestCase):
 
@@ -1973,6 +1980,10 @@ class InsertedDocumentTest(TestCase):
         self.data = {"a": 1, "b": [1, 2, 3], "c": {"d": 4}}
         self.orig_data = copy.deepcopy(self.data)
         self.object_id = self.collection.insert(self.data)
+
+    def test__object_distinct_fields(self):
+        self.collection.insert({'a': {'b': 'bbb', 'c': 'ccc'}})
+        print self.collection.find()
 
     def test__object_is_consistent(self):
         [object] = self.collection.find()

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1965,6 +1965,7 @@ class MongoClientSortSkipLimitTest(_CollectionComparisonTest):
         self.cmp.do(lambda cursor: cursor.close()).find()
 
     def test__multiple_projection_values(self):
+        # before my fix, mongomock used to fail when projection had complex field, such as tested here:
         self.cmp.do.remove()
         data = {"book_id": 123, "book_translations": [{"translator": 'Sagy', "language": 'Hebrew'},
                                                       {"translator": 'Yuri', "language": 'Russian'}]}
@@ -1980,10 +1981,6 @@ class InsertedDocumentTest(TestCase):
         self.data = {"a": 1, "b": [1, 2, 3], "c": {"d": 4}}
         self.orig_data = copy.deepcopy(self.data)
         self.object_id = self.collection.insert(self.data)
-
-    def test__object_distinct_fields(self):
-        self.collection.insert({'a': {'b': 'bbb', 'c': 'ccc'}})
-        print self.collection.find()
 
     def test__object_is_consistent(self):
         [object] = self.collection.find()


### PR DESCRIPTION
E.g running Book.objects().only('book_data.name', 'book_data.length') doesn't work
before this fix because the key_parts[-2] (AKA book_data) is common for those 2 keys so
they override each other.