### PR TITLE
Implement  $count in aggregate pipeline

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -13,7 +13,6 @@ If i miss to include a feature in the below list, Please feel free to add to the
   * `$addFields <https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/>`_
   * `$bucketAuto <https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/>`_
   * `$collStats <https://docs.mongodb.com/manual/reference/operator/aggregation/collStats/>`_
-  * `$count <https://docs.mongodb.com/manual/reference/operator/aggregation/count/>`_
   * `$currentOp <https://docs.mongodb.com/manual/reference/operator/aggregation/currentOp/>`_
   * `$facet <https://docs.mongodb.com/manual/reference/operator/aggregation/facet/>`_
   * `$geoNear <https://docs.mongodb.com/manual/reference/operator/aggregation/geoNear/>`_

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -725,12 +725,18 @@ def _handle_out_stage(in_collection, database, options):
     return in_collection
 
 
+def _handle_count_stage(in_collection, database, options):
+    if not isinstance(options, str) or options == '':
+        raise OperationFailure('the count field must be a non-empty string')
+    return [{options: len(in_collection)}]
+
+
 _PIPELINE_HANDLERS = {
     '$addFields': None,
     '$bucket': _handle_bucket_stage,
     '$bucketAuto': None,
     '$collStats': None,
-    '$count': None,
+    '$count': _handle_count_stage,
     '$currentOp': None,
     '$facet': None,
     '$geoNear': None,

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -728,6 +728,10 @@ def _handle_out_stage(in_collection, database, options):
 def _handle_count_stage(in_collection, database, options):
     if not isinstance(options, str) or options == '':
         raise OperationFailure('the count field must be a non-empty string')
+    elif options.startswith('$'):
+        raise OperationFailure('the count field cannot be a $-prefixed path')
+    elif '.' in options:
+        raise OperationFailure("the count field cannot contain '.'")
     return [{options: len(in_collection)}]
 
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2084,7 +2084,7 @@ class CollectionAPITest(TestCase):
             for i in range(5)
         ])
         # Many cases for '$count' options that should raise an operation failure.
-        cases = (None, 3, {}, '', [])
+        cases = (None, 3, {}, [], '', '$one_count', 'one.count')
         for case in cases:
             with self.assertRaises(mongomock.OperationFailure):
                 self.db.a.aggregate([{'$count': case}])

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2065,6 +2065,30 @@ class CollectionAPITest(TestCase):
             with self.assertRaises(mongomock.OperationFailure):
                 self.db.a.aggregate([{'$sample': case}])
 
+    def test__aggregate_count(self):
+        self.db.a.insert_many([
+            {'_id': 1, 'a': 1},
+            {'_id': 2, 'a': 2},
+            {'_id': 3, 'a': 1}
+        ])
+
+        actual = list(self.db.a.aggregate([
+            {'$match': {'a': 1}},
+            {'$count': 'one_count'}
+        ]))
+        self.assertEqual([{'one_count': 2}], actual)
+
+    def test__aggregate_count_errors(self):
+        self.db.a.insert_many([
+            {'_id': i}
+            for i in range(5)
+        ])
+        # Many cases for '$count' options that should raise an operation failure.
+        cases = (None, 3, {}, '', [])
+        for case in cases:
+            with self.assertRaises(mongomock.OperationFailure):
+                self.db.a.aggregate([{'$count': case}])
+
     def test__aggregate_project_array_size(self):
         self.db.collection.insert_one({'_id': 1, 'arr': [2, 3]})
         actual = self.db.collection.aggregate([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2287,6 +2287,14 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             'default': 'Other',
         }}])
 
+    def test__aggregate_count(self):
+        self.cmp.do.insert_many([
+            {'_id': i} for i in range(5)
+        ])
+        self.cmp.compare.aggregate([
+            {'$count': 'my_count'}
+        ])
+
     def test__aggregate_project_rotate(self):
         self.cmp.do.insert_one({'_id': 1, 'a': 1, 'b': 2, 'c': 3})
         self.cmp.compare.aggregate([


### PR DESCRIPTION
`$count` is not yet implemented in MongoMock pipelines hence this PR !