### PR TITLE
Allow falsy value for _id in update operations.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -721,7 +721,7 @@ class Collection(object):
                                 raise ValueError('field names cannot start with $ [{}]'.format(k))
                         _id = spec.get('_id', existing_document.get('_id'))
                         existing_document.clear()
-                        if _id:
+                        if _id is not None:
                             existing_document['_id'] = _id
                         if BSON:
                             # bson validation

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -622,6 +622,12 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(mongomock.OperationFailure):
             self.db.collection.update({'_id': 1}, {'_id': 2, 'b': 2})
 
+    def test__update_empty_id(self):
+        self.db.collection.save({'_id': '', 'a': 1})
+        self.db.collection.replace_one({'_id': ''}, {'b': 1})
+        doc = self.db.collection.find_one({'_id': ''})
+        self.assertEqual(1, doc['b'])
+
     def test__update_one(self):
         insert_result = self.db.collection.insert_one({'a': 1})
         update_result = self.db.collection.update_one(

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -938,6 +938,11 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             {'a': 1}, {'_id': ObjectId('52d669dcad547f059424f783'), 'a': 1}, upsert=True)
         self.cmp.compare.find()
 
+    def test__update_with_zero_id(self):
+        self.cmp.do.insert_one({'_id': 0})
+        self.cmp.do.replace_one({'_id': 0}, {'a': 1})
+        self.cmp.compare.find()
+
     def test__update_upsert_with_dots(self):
         self.cmp.do.update(
             {'a.b': 1}, {'$set': {'c': 2}}, upsert=True)


### PR DESCRIPTION
Fixes #482 