### PR TITLE
fix DuplicateKeyError when parse None to sparse unique index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,7 @@ Also, many thanks go to the following people for helping out, contributing pull 
 * tipok
 * waskew (waskew _at_ narrativescience.com)
 * jmsantorum (jmsantorum [at] gmail [dot] com)
+* lidongyong
 
 
 .. _examples in tests: https://github.com/vmalloc/mongomock/blob/master/tests/test__mongomock.py#L108

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1328,6 +1328,8 @@ class Collection(object):
                         if is_sparse:
                             continue
                         index.append(None)
+                if is_sparse and not index:
+                    continue
                 index = tuple(index)
                 if index in indexed:
                     raise DuplicateKeyError('E11000 Duplicate Key Error', 11000)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -131,6 +131,17 @@ class DatabaseGettingTest(TestCase):
         result = collection.find({})
         self.assertEqual(result.count(), 3)
 
+    def test__sparse_unique_index(self):
+        db = self.client.somedb
+        collection = db.a
+        collection.create_index([('value', 1)], unique=True, sparse=True)
+
+        collection.insert({'value': 'should_be_unique'})
+        collection.insert({'simple': 'simple_without_value'})
+        collection.insert({'simple': 'simple_without_value2'})
+
+        collection.ensure_index([('value', 1)], unique=True, sparse=True)
+
     def test__alive(self):
         self.assertTrue(self.client.alive())
 


### PR DESCRIPTION
I got DuplicateKeyError when I create model with None value for a key which index is unque and sparse. but, with mongoengine, it works fine.
```
class Device(Documnet):
     key_1 = StringField(max_length=256)
     key_2 = StringField(max_length=256)
     
     meta = {
        "collection": "devices",
        "indexes": [
            {
                "fields": ["key_1"],
                "unique": True,
                "sparse": True
            },

d1 = Device(key1='a', key2='b').save()
d2 = Device(key2='b').save()  # key1 is None
d3 = Device(key2='c').save()  # key1 is None
```

I got DuplicateKeyError when I create d3 use mongomock