### PR TITLE
Fixing unkown expected behavior for patch(servers=...) decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ mongomock.patch:
 
 .. code-block:: python
 
-  @mongomock.patch(servers=(('server.example.com', 27017),))
+  @mongomock.patch(servers='server.example.com:27017,another.example.com:9999')
   def test_increate_votes_endpoint():
     objects = [dict(votes=1), dict(votes=2), ...]
     client = pymongo.MongoClient('server.example.com')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sentinels
 six
+pymongo

--- a/tests/test__client_api.py
+++ b/tests/test__client_api.py
@@ -92,7 +92,7 @@ class MongoClientApiTest(unittest.TestCase):
             client = mongomock.MongoClient()
             client.one_db.my_collec.insert_one({})
             mock_warn.assert_not_called()
-            self.assertEqual(['one_db'], client.database_names())
+            self.assertEqual(['one_db'], client.list_database_names())
             self.assertEqual(1, mock_warn.call_count)
             self.assertIn('deprecated', mock_warn.call_args[0][0])
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2682,6 +2682,6 @@ class DatabasesNamesTest(TestCase):
     def test__database_names(self):
         self.client.unit.tests.insert({'foo': 'bar'})
         self.client.foo.bar.insert({'unit': 'test'})
-        names = self.client.database_names()
+        names = self.client.list_database_names()
         self.assertIsInstance(names, list)
         self.assertEqual(sorted(['foo', 'unit']), sorted(names))

--- a/tests/test__patch.py
+++ b/tests/test__patch.py
@@ -33,11 +33,24 @@ class PatchTest(unittest.TestCase):
         client1.db.coll.insert_one({'name': 'Pascal'})
 
         client2 = pymongo.MongoClient()
-        self.assertEqual(['db'], client2.database_names())
+        self.assertEqual(['db'], client2.list_database_names())
         self.assertEqual('Pascal', client2.db.coll.find_one()['name'])
         client2.db.coll.drop()
 
         self.assertEqual(None, client1.db.coll.find_one())
+
+    @mongomock.patch(servers="test.server.com:134,test2.server.com:456")
+    def test__decorator_with_servers(self):
+        for host, port in zip(["test.server.com,test2.server.com"], [134, 456]):
+            client1 = pymongo.MongoClient(host=host, port=port)
+            client1.db.coll.insert_one({'name': 'Pascal'})
+
+            client2 = pymongo.MongoClient(host=host, port=port)
+            self.assertEqual(['db'], client2.list_database_names())
+            self.assertEqual('Pascal', client2.db.coll.find_one()['name'])
+            client2.db.coll.drop()
+
+            self.assertEqual(None, client1.db.coll.find_one())
 
     @mongomock.patch(on_new='create')
     def test__create_new(self):


### PR DESCRIPTION
As described in #511 it is unclear how to add servers to patch, since the Readme doesn't fit the actual behavior.
The fix is actually to the README file - added unittest so that this kind of behavior won't be missed later on.
Full changes list:
1. Fixing Readme to show the correct behavior of current code (patch(servers=...) behavior).
2. Adding unittest for patch(servers=...)
3. Fixing internal deprecations in unit tests
4. Adding pymongo to requirements to allow for unit tests to run.