### PR TITLE
Incoherent patch(servers=...) behavior

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ mongomock.patch:
 
 .. code-block:: python
 
-  @mongomock.patch(servers=(('server.example.com', 27017),))
+  @mongomock.patch(servers='server.example.com:27017,server2.example.com:9999')
   def test_increate_votes_endpoint():
     objects = [dict(votes=1), dict(votes=2), ...]
     client = pymongo.MongoClient('server.example.com')

--- a/tests/test__patch.py
+++ b/tests/test__patch.py
@@ -47,9 +47,9 @@ class PatchTest(unittest.TestCase):
         client2 = pymongo.MongoClient(host='myserver.example.com', port=12345)
         self.assertEqual('Pascal', client2.db.coll.find_one()['name'])
 
-    @mongomock.patch(servers="test.server.com:134,test2.server.com:456")
+    @mongomock.patch(servers='test.server.com:134,test2.server.com:456')
     def test__decorator_with_servers(self):
-        for host, port in zip(["test.server.com,test2.server.com"], [134, 456]):
+        for host, port in zip(['test.server.com,test2.server.com'], [134, 456]):
             client1 = pymongo.MongoClient(host=host, port=port)
             client1.db.coll.insert_one({'name': 'Pascal'})
 

--- a/tests/test__patch.py
+++ b/tests/test__patch.py
@@ -47,6 +47,19 @@ class PatchTest(unittest.TestCase):
         client2 = pymongo.MongoClient(host='myserver.example.com', port=12345)
         self.assertEqual('Pascal', client2.db.coll.find_one()['name'])
 
+    @mongomock.patch(servers="test.server.com:134,test2.server.com:456")
+    def test__decorator_with_servers(self):
+        for host, port in zip(["test.server.com,test2.server.com"], [134, 456]):
+            client1 = pymongo.MongoClient(host=host, port=port)
+            client1.db.coll.insert_one({'name': 'Pascal'})
+
+            client2 = pymongo.MongoClient(host=host, port=port)
+            self.assertEqual(['db'], client2.list_database_names())
+            self.assertEqual('Pascal', client2.db.coll.find_one()['name'])
+            client2.db.coll.drop()
+
+            self.assertEqual(None, client1.db.coll.find_one())
+
     @mongomock.patch()
     def test__error_new(self):
         # Valid because using the default server which was whitelisted by default.


### PR DESCRIPTION
As described in #511 it is unclear how to add servers to patch, since the Readme doesn't fit the actual behavior.
The fix is actually to the README file - added unittest so that this kind of behavior won't be missed later on.
In this fix:
Fixing Readme to show the correct behavior of current code (patch(servers=...) behavior).
Adding unittest for patch(servers=...)