### PR TITLE
Added string operations support

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -28,7 +28,6 @@ If I miss to include a feature in the below list, Please feel free to add to the
     * `$subtract <https://docs.mongodb.com/manual/reference/operator/aggregation/subtract/>`_
   * Boolean operators ($and, $or, $not)
   * Some set operators ($setEquals, $setIntersection, $setDifference, …)
-  * String operators ($concat, $strcasecmp, $substr, …)
   * Text search operator ($meta)
   * Projection operators ($map, $let)
   * Array operators ($concatArrays, $isArray, $slice)

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -5,7 +5,6 @@ import collections
 import copy
 import datetime
 import itertools
-
 import math
 import numbers
 import random

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -6,6 +6,8 @@ import copy
 import datetime
 import functools
 import itertools
+import warnings
+
 import math
 import numbers
 import random
@@ -277,6 +279,9 @@ class _Parser(object):
             length = self.parse(values[2])
             if string is None or first < 0:
                 return ''
+            if length < 0:
+                warnings.warn('Negative length given to $substr is accepted only until '
+                              'MongoDB 3.7. This behavior will vhange in the future.')
             second = len(string) if length < 0 else first + length
             return string[first:second]
         if operator == '$strcasecmp':

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -5,11 +5,12 @@ import collections
 import copy
 import datetime
 import itertools
-import warnings
 
 import math
 import numbers
 import random
+import warnings
+
 import six
 from six import moves
 

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -277,11 +277,15 @@ class _Parser(object):
             string = str(self.parse(values[0]))
             first = self.parse(values[1])
             length = self.parse(values[2])
-            if string is None or first < 0:
+            if string is None:
+                return ''
+            if first < 0:
+                warnings.warn('Negative starting point given to $substr is accepted only until '
+                              'MongoDB 3.7. This behavior will change in the future.')
                 return ''
             if length < 0:
                 warnings.warn('Negative length given to $substr is accepted only until '
-                              'MongoDB 3.7. This behavior will vhange in the future.')
+                              'MongoDB 3.7. This behavior will change in the future.')
             second = len(string) if length < 0 else first + length
             return string[first:second]
         if operator == '$strcasecmp':

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -86,8 +86,6 @@ string_operators = [
     '$substr',
     '$toLower',
     '$toUpper',
-]
-misc_operators = [
     '$toString',
 ]
 comparison_operators = [
@@ -162,8 +160,6 @@ class _Parser(object):
                 return self._handle_set_operator(k, v)
             if k in string_operators:
                 return self._handle_string_operator(k, v)
-            if k in misc_operators:
-                return self._handle_misc_operator(k, v)
             if k in boolean_operators + \
                     text_search_operators + projection_operators:
                 raise NotImplementedError(
@@ -263,24 +259,18 @@ class _Parser(object):
             'aggregation pipeline, it is currently not implemented '
             ' in Mongomock.' % operator)
 
-    def _handle_misc_operator(self, operator, values):
-        if operator == '$toString':
-            parsed = self.parse(values)
-            return str(parsed) if parsed is not None else None
-            # This should never happen: it is only a safe fallback if something went wrong.
-        raise NotImplementedError(  # pragma: no cover
-            "Although '%s' is a valid operator for the aggregation "
-            'pipeline, it is currently not implemented  in Mongomock.' % operator)
-
     def _handle_string_operator(self, operator, values):
         if operator == '$toLower':
-            return str(self.parse(values)).lower()
+            parsed = self.parse(values)
+            return str(parsed).lower() if parsed is not None else ''
         if operator == '$toUpper':
-            return str(self.parse(values)).upper()
+            parsed = self.parse(values)
+            return str(parsed).upper() if parsed is not None else ''
         if operator == '$concat':
             return ''.join([str(self.parse(value)) for value in values])
         if operator == '$substr':
-            assert len(values) == 3, 'substr must have 3 items'
+            if len(values) != 3:
+                raise OperationFailure('substr must have 3 items')
             string = str(self.parse(values[0]))
             first = self.parse(values[1])
             length = self.parse(values[2])
@@ -289,9 +279,13 @@ class _Parser(object):
             second = len(string) if length < 0 else first + length
             return string[first:second]
         if operator == '$strcasecmp':
-            assert len(values) == 2, 'strcasecmp must have 2 items'
+            if len(values) != 2:
+                raise OperationFailure('strcasecmp must have 2 items')
             a, b = str(self.parse(values[0])), str(self.parse(values[1]))
             return 0 if a == b else -1 if a < b else 1
+        if operator == '$toString':
+            parsed = self.parse(values)
+            return str(parsed) if parsed is not None else None
         # This should never happen: it is only a safe fallback if something went wrong.
         raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid string operator for the aggregation "

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -86,7 +86,7 @@ string_operators = [
     '$substr',
     '$toLower',
     '$toUpper',
-    '$toString',
+    # '$toString',
 ]
 comparison_operators = [
     '$cmp',
@@ -267,7 +267,8 @@ class _Parser(object):
             parsed = self.parse(values)
             return str(parsed).upper() if parsed is not None else ''
         if operator == '$concat':
-            return ''.join([str(self.parse(value)) for value in values])
+            parsed_list = [self.parse(value) for value in values]
+            return None if None in parsed_list else ''.join([str(x) for x in parsed_list])
         if operator == '$substr':
             if len(values) != 3:
                 raise OperationFailure('substr must have 3 items')
@@ -283,9 +284,10 @@ class _Parser(object):
                 raise OperationFailure('strcasecmp must have 2 items')
             a, b = str(self.parse(values[0])), str(self.parse(values[1]))
             return 0 if a == b else -1 if a < b else 1
-        if operator == '$toString':
-            parsed = self.parse(values)
-            return str(parsed) if parsed is not None else None
+        # TODO: Re-enable once TRAVIS supports MongoDB 4
+        # if operator == '$toString':
+        #     parsed = self.parse(values)
+        #     return str(parsed) if parsed is not None else None
         # This should never happen: it is only a safe fallback if something went wrong.
         raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid string operator for the aggregation "

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -284,7 +284,7 @@ class _Parser(object):
                 raise OperationFailure('strcasecmp must have 2 items')
             a, b = str(self.parse(values[0])), str(self.parse(values[1]))
             return 0 if a == b else -1 if a < b else 1
-        # TODO: Re-enable once TRAVIS supports MongoDB 4
+        # TODO(ymoran00): Re-enable once TRAVIS supports MongoDB 4
         # if operator == '$toString':
         #     parsed = self.parse(values)
         #     return str(parsed) if parsed is not None else None

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -86,7 +86,7 @@ string_operators = [
     '$substr',
     '$toLower',
     '$toUpper',
-    # '$toString',
+    '$toString',
 ]
 comparison_operators = [
     '$cmp',
@@ -284,10 +284,9 @@ class _Parser(object):
                 raise OperationFailure('strcasecmp must have 2 items')
             a, b = str(self.parse(values[0])), str(self.parse(values[1]))
             return 0 if a == b else -1 if a < b else 1
-        # TODO(ymoran00): Re-enable once TRAVIS supports MongoDB 4
-        # if operator == '$toString':
-        #     parsed = self.parse(values)
-        #     return str(parsed) if parsed is not None else None
+        if operator == '$toString':
+            parsed = self.parse(values)
+            return str(parsed) if parsed is not None else None
         # This should never happen: it is only a safe fallback if something went wrong.
         raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid string operator for the aggregation "

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -15,7 +15,7 @@ from mongomock.write_concern import WriteConcern
 
 try:
     from bson.errors import InvalidDocument
-    from bson import tz_util, ObjectId
+    from bson import tz_util
     import pymongo
     from pymongo.collation import Collation
     from pymongo.read_preferences import ReadPreference

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2605,6 +2605,7 @@ class CollectionAPITest(TestCase):
         })
         actual = self.db.collection.aggregate([{'$project': {
             'concat': {'$concat': ['$a', ' Dear ', '$b']},
+            'concat_none': {'$concat': ['$a', None, '$b']},
             'sub1': {'$substr': ['$a', 0, 4]},
             'sub2': {'$substr': ['$a', -1, 3]},
             'sub3': {'$substr': ['$a', 2, -1]},
@@ -2612,24 +2613,24 @@ class CollectionAPITest(TestCase):
             'lower_err': {'$toLower': None},
             'upper': {'$toUpper': '$a'},
             'upper_err': {'$toUpper': None},
-            'toStr': {'$toString': '$c'}
         }}])
         self.assertEqual(
-            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '', 'sub3': 'llo', 'lower': 'hello',
-              'lower_err': '', 'upper': 'HELLO', 'upper_err': '', 'toStr': '3'}],
+            [{'concat': 'Hello Dear World', 'concat_none': None, 'sub1': 'Hell', 'sub2': '',
+              'sub3': 'llo', 'lower': 'hello', 'lower_err': '', 'upper': 'HELLO', 'upper_err': ''}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
-    @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
-    def test__aggregate_tostr_operation_objectid(self):
-        self.db.collection.insert_one({
-            'a': ObjectId('5abcfad1fbc93d00080cfe66')
-        })
-        actual = self.db.collection.aggregate([{'$project': {
-            'toString': {'$toString': '$a'},
-        }}])
-        self.assertEqual(
-            [{'toString': '5abcfad1fbc93d00080cfe66'}],
-            [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
+    # TODO: Re-enable once TRAVIS supports MongoDB 4
+    # @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
+    # def test__aggregate_tostr_operation_objectid(self):
+    #     self.db.collection.insert_one({
+    #         'a': ObjectId('5abcfad1fbc93d00080cfe66')
+    #     })
+    #     actual = self.db.collection.aggregate([{'$project': {
+    #         'toString': {'$toString': '$a'},
+    #     }}])
+    #     self.assertEqual(
+    #         [{'toString': '5abcfad1fbc93d00080cfe66'}],
+    #         [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     def test__aggregate_unrecognized(self):
         self.db.collection.insert_one({})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2601,41 +2601,33 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_one({
             'a': 'Hello',
             'b': 'World',
+            'c': 3
         })
         actual = self.db.collection.aggregate([{'$project': {
             'concat': {'$concat': ['$a', ' Dear ', '$b']},
             'sub1': {'$substr': ['$a', 0, 4]},
             'sub2': {'$substr': ['$a', -1, 3]},
             'lower': {'$toLower': '$a'},
+            'lower_err': {'$toLower': None},
             'upper': {'$toUpper': '$a'},
+            'upper_err': {'$toUpper': None},
+            'toStr': {'$toString': '$c'}
         }}])
         self.assertEqual(
-            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '',
-              'lower': 'hello', 'upper': 'HELLO'}],
+            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '', 'lower': 'hello',
+              'lower_err': '', 'upper': 'HELLO', 'upper_err': '', 'toStr': '3'}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
-    def test__aggregate_misc_operations_objectid(self):
-        _id = ObjectId()
+    def test__aggregate_tostr_operation_objectid(self):
         self.db.collection.insert_one({
-            'a': _id
+            'a': ObjectId('5abcfad1fbc93d00080cfe66')
         })
         actual = self.db.collection.aggregate([{'$project': {
             'toString': {'$toString': '$a'},
         }}])
         self.assertEqual(
-            [{'toString': str(_id)}],
-            [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
-
-    def test__aggregate_misc_operations(self):
-        self.db.collection.insert_one({
-            'a': 3,
-        })
-        actual = self.db.collection.aggregate([{'$project': {
-            'toString': {'$toString': '$a'},
-        }}])
-        self.assertEqual(
-            [{'toString': '3'}],
+            [{'toString': '5abcfad1fbc93d00080cfe66'}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     def test__aggregate_unrecognized(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2610,21 +2610,32 @@ class CollectionAPITest(TestCase):
             'upper': {'$toUpper': '$a'},
         }}])
         self.assertEqual(
-            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '', 'lower': 'hello', 'upper': 'HELLO'}],
+            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '',
+              'lower': 'hello', 'upper': 'HELLO'}],
+            [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
+
+    @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
+    def test__aggregate_misc_operations_objectid(self):
+        _id = ObjectId()
+        self.db.collection.insert_one({
+            'a': _id
+        })
+        actual = self.db.collection.aggregate([{'$project': {
+            'toString': {'$toString': '$a'},
+        }}])
+        self.assertEqual(
+            [{'toString': str(_id)}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     def test__aggregate_misc_operations(self):
-        _id = ObjectId()
         self.db.collection.insert_one({
-            'a': _id,
-            'b': 3,
+            'a': 3,
         })
         actual = self.db.collection.aggregate([{'$project': {
-            'toString1': {'$toString': '$a'},
-            'toString2': {'$toString': '$b'},
+            'toString': {'$toString': '$a'},
         }}])
         self.assertEqual(
-            [{'toString1': str(_id), 'toString2': '3'}],
+            [{'toString': '3'}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     def test__aggregate_unrecognized(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2617,7 +2617,8 @@ class CollectionAPITest(TestCase):
         }}])
         self.assertEqual(
             [{'concat': 'Hello Dear World', 'concat_none': None, 'sub1': 'Hell', 'sub2': '',
-              'sub3': 'llo', 'lower': 'hello', 'lower_err': '', 'strcasecmp': -1, 'upper': 'HELLO', 'upper_err': ''}],
+              'sub3': 'llo', 'lower': 'hello', 'lower_err': '', 'strcasecmp': -1,
+              'upper': 'HELLO', 'upper_err': ''}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
     def test__strcmp_not_enough_params(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2607,6 +2607,7 @@ class CollectionAPITest(TestCase):
             'concat': {'$concat': ['$a', ' Dear ', '$b']},
             'sub1': {'$substr': ['$a', 0, 4]},
             'sub2': {'$substr': ['$a', -1, 3]},
+            'sub3': {'$substr': ['$a', 2, -1]},
             'lower': {'$toLower': '$a'},
             'lower_err': {'$toLower': None},
             'upper': {'$toUpper': '$a'},
@@ -2614,7 +2615,7 @@ class CollectionAPITest(TestCase):
             'toStr': {'$toString': '$c'}
         }}])
         self.assertEqual(
-            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '', 'lower': 'hello',
+            [{'concat': 'Hello Dear World', 'sub1': 'Hell', 'sub2': '', 'sub3': 'llo', 'lower': 'hello',
               'lower_err': '', 'upper': 'HELLO', 'upper_err': '', 'toStr': '3'}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2619,7 +2619,7 @@ class CollectionAPITest(TestCase):
               'sub3': 'llo', 'lower': 'hello', 'lower_err': '', 'upper': 'HELLO', 'upper_err': ''}],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
 
-    # TODO: Re-enable once TRAVIS supports MongoDB 4
+    # TODO(ymoran00): Re-enable once TRAVIS supports MongoDB 4
     # @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     # def test__aggregate_tostr_operation_objectid(self):
     #     self.db.collection.insert_one({

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2276,6 +2276,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             'minNone': {'$min': [None, None]},
             'avgNone': {'$avg': ['a', None]},
             'sumNone': {'$sum': ['a', None]},
+            'toString':{'$toString': '$a'}
         }}]
         self.cmp.compare.aggregate(pipeline)
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2275,8 +2275,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             'maxNone': {'$max': [None, None]},
             'minNone': {'$min': [None, None]},
             'avgNone': {'$avg': ['a', None]},
-            'sumNone': {'$sum': ['a', None]},
-            'toString':{'$toString': '$a'}
+            'sumNone': {'$sum': ['a', None]}
         }}]
         self.cmp.compare.aggregate(pipeline)
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2275,7 +2275,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             'maxNone': {'$max': [None, None]},
             'minNone': {'$min': [None, None]},
             'avgNone': {'$avg': ['a', None]},
-            'sumNone': {'$sum': ['a', None]}
+            'sumNone': {'$sum': ['a', None]},
         }}]
         self.cmp.compare.aggregate(pipeline)
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2279,6 +2279,24 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         }}]
         self.cmp.compare.aggregate(pipeline)
 
+    def test__aggregate34(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({'_id': 1, 'a': 'Hellp', 'b': 'World'})
+        pipeline = [{'$project': {
+            '_id': 0,
+            'concat': {'$concat': ['$a', ' Dear ', '$b']},
+            'concat_none': {'$concat': ['$a', None, '$b']},
+            'sub1': {'$substr': ['$a', 0, 4]},
+            'sub2': {'$substr': ['$a', -1, 3]},
+            'sub3': {'$substr': ['$a', 2, -1]},
+            'lower': {'$toLower': '$a'},
+            'lower_err': {'$toLower': None},
+            'strcasecmp': {'$strcasecmp': ['$a', '$b']},
+            'upper': {'$toUpper': '$a'},
+            'upper_err': {'$toUpper': None},
+        }}]
+        self.cmp.compare.aggregate(pipeline)
+
     def test__aggregate_project_id_0(self):
         self.cmp.do.remove()
         self.cmp.do.insert([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2281,14 +2281,12 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
 
     def test__aggregate34(self):
         self.cmp.do.drop()
-        self.cmp.do.insert_one({'_id': 1, 'a': 'Hellp', 'b': 'World'})
+        self.cmp.do.insert_one({'_id': 1, 'a': 'Hello', 'b': 'World'})
         pipeline = [{'$project': {
             '_id': 0,
             'concat': {'$concat': ['$a', ' Dear ', '$b']},
             'concat_none': {'$concat': ['$a', None, '$b']},
             'sub1': {'$substr': ['$a', 0, 4]},
-            'sub2': {'$substr': ['$a', -1, 3]},
-            'sub3': {'$substr': ['$a', 2, -1]},
             'lower': {'$toLower': '$a'},
             'lower_err': {'$toLower': None},
             'strcasecmp': {'$strcasecmp': ['$a', '$b']},


### PR DESCRIPTION
Added support for aggregation operators - all string operations that weren't supported yet, and a new $toString operation that was added in mongodb 4.0