### PR TITLE
BulkOperationBuilder: Call insert_one rather than deprecated insert

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -266,7 +266,7 @@ class BulkOperationBuilder(object):
 
     def insert(self, doc):
         def exec_insert():
-            self.collection.insert(doc)
+            self.collection.insert_one(doc)
             return {'nInserted': 1}
         self.executors.append(exec_insert)
 


### PR DESCRIPTION
Currently, using mongomock, with a recent PyMongo we get:

`site-packages/mongomock/collection.py:266: DeprecationWarning: insert is deprecated. Use insert_one or insert_many instead.
    self.collection.insert(doc)`

This PR tries to remove the warning. 