### PR TITLE
Handle array subfields in the  stage of the aggregate pipeline.

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -813,6 +813,9 @@ def _project_by_spec(doc, proj_spec, is_include):
 
         if isinstance(value, dict):
             output[key] = _project_by_spec(value, proj_spec[key], is_include)
+        elif isinstance(value, list):
+            output[key] = [_project_by_spec(array_value, proj_spec[key], is_include)
+                           for array_value in value if isinstance(array_value, dict)]
         elif not is_include:
             output[key] = value
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -3175,6 +3175,40 @@ class CollectionAPITest(TestCase):
             [{'_id': 1, 'max': 9, 'min': 2, 'avg': 3, 'sum': 13, 'maxString': '$d'}],
             list(actual))
 
+    def test__aggregate_project_array_subfield(self):
+        self.db.collection.insert_many([
+            {'a': [{'b': 1, 'c': 2, 'd': 3}], 'e': 4},
+            {'a': [{'c': 12, 'd': 13}], 'e': 14},
+            {'a': [{'b': 21, 'd': 23}], 'e': 24},
+            {'a': [{'b': 31, 'c': 32}], 'e': 34},
+            {'a': [{'b': 41}], 'e': 44},
+            {'a': [{'c': 51}], 'e': 54},
+            {'a': [{'d': 51}], 'e': 54},
+            {'a': [{'b': 61, 'c': 62, 'd': 63}, 65, 'foobar',
+                   {'b': 66, 'c': 67, 'd': 68}], 'e': 64},
+            {'a': []},
+            {'a': [1, 2, 3, 4]},
+            {'a': 'foobar'},
+            {'a': 5},
+        ])
+        actual = self.db.collection.aggregate([
+            {'$project': {'a.b': 1, 'a.c': 1, '_id': 0}}
+        ])
+        self.assertEqual(list(actual), [
+            {'a': [{'b': 1, 'c': 2}]},
+            {'a': [{'c': 12}]},
+            {'a': [{'b': 21}]},
+            {'a': [{'b': 31, 'c': 32}]},
+            {'a': [{'b': 41}]},
+            {'a': [{'c': 51}]},
+            {'a': [{}]},
+            {'a': [{'b': 61, 'c': 62}, {'b': 66, 'c': 67}]},
+            {'a': []},
+            {'a': []},
+            {},
+            {},
+        ])
+
     def test__aggregate_arithmetic(self):
         self.db.collection.insert_one({
             'a': 1.5,

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2403,6 +2403,25 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         pipeline = [{'$project': {'_id': 0}}]
         self.cmp.compare_ignore_order.aggregate(pipeline)
 
+    def test__aggregate_project_array_subfield(self):
+        self.cmp.do.insert_many([
+            {'a': [{'b': 1, 'c': 2, 'd': 3}], 'e': 4},
+            {'a': [{'c': 12, 'd': 13}], 'e': 14},
+            {'a': [{'b': 21, 'd': 23}], 'e': 24},
+            {'a': [{'b': 31, 'c': 32}], 'e': 34},
+            {'a': [{'b': 41}], 'e': 44},
+            {'a': [{'c': 51}], 'e': 54},
+            {'a': [{'d': 51}], 'e': 54},
+            {'a': [{'b': 61, 'c': 62, 'd': 63}, 65, 'foobar',
+                   {'b': 66, 'c': 67, 'd': 68}], 'e': 64},
+            {'a': []},
+            {'a': [1, 2, 3, 4]},
+            {'a': 'foobar'},
+            {'a': 5},
+        ])
+        pipeline = [{'$project': {'a.b': 1, 'a.c': 1, '_id': 0}}]
+        self.cmp.compare_ignore_order.aggregate(pipeline)
+
     def test__aggregate_bucket(self):
         self.cmp.do.remove()
         self.cmp.do.insert_many([


### PR DESCRIPTION
While testing some $slice on aggregations, in noticed, arrays subfields inclusions were ignored.

Here is a fix :)
