### PR TITLE
Consider "name" argument to create_index for index name

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1369,7 +1369,7 @@ class Collection(object):
         is_unique = kwargs.pop('unique', False)
         is_sparse = kwargs.pop('sparse', False)
 
-        index_string = helpers.gen_index_name(index_list)
+        index_name = kwargs.pop('name', helpers.gen_index_name(index_list))
         index_dict = {'key': index_list}
         if is_sparse:
             index_dict['sparse'] = True
@@ -1394,9 +1394,9 @@ class Collection(object):
                     raise DuplicateKeyError('E11000 Duplicate Key Error', 11000)
                 indexed.add(index)
 
-        self._store.indexes[index_string] = index_dict
+        self._store.indexes[index_name] = index_dict
 
-        return index_string
+        return index_name
 
     def create_indexes(self, indexes, session=None):
         for index in indexes:

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1408,7 +1408,8 @@ class Collection(object):
                 index.document['key'].items(),
                 session=session,
                 unique=index.document.get('unique', False),
-                sparse=index.document.get('sparse', False))
+                sparse=index.document.get('sparse', False),
+                name=index.document.get('name'))
             for index in indexes
         ]
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1295,6 +1295,15 @@ class CollectionAPITest(TestCase):
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
+    def test__create_indexes_names(self):
+        indexes = [
+            pymongo.operations.IndexModel([('value', pymongo.ASCENDING)], name='index_name'),
+            pymongo.operations.IndexModel([('name', pymongo.ASCENDING)], unique=True)
+        ]
+        index_names = self.db.collection.create_indexes(indexes)
+        self.assertEqual(['index_name', 'name_1'], index_names)
+
+    @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__ensure_uniq_idxs_with_ascending_ordering(self):
         self.db.collection.ensure_index([('value', pymongo.ASCENDING)], unique=True)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1430,6 +1430,13 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert({'value': 1})
         self.assertEqual(self.db.collection.find({}).count(), 3)
 
+    @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
+    def test__create_index_with_name(self):
+        name = self.db.collection.create_index([('value', 1)], name='index_name')
+        self.assertEqual('index_name', name)
+        self.db.collection.ensure_index([('value', 1)], name='index_name')
+        self.assertEqual({'_id_', 'index_name'}, set(self.db.collection.index_information().keys()))
+
     def test__insert_empty_doc_idx_information(self):
         self.db.collection.insert({})
 


### PR DESCRIPTION
Current version does not allow giving a human readable index name.