### PR TITLE
Bytes sort

### DIFF
--- a/tests/diff.py
+++ b/tests/diff.py
@@ -11,7 +11,7 @@ class _NO_VALUE(object):
 NO_VALUE = _NO_VALUE()
 
 _SUPPORTED_TYPES = (float, bool, str, datetime.datetime, type(None)) + \
-    string_types + integer_types + (text_type,)
+    string_types + integer_types + (text_type, bytes)
 
 if python_version() < '3.0':
     dict_type = dict

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -3740,9 +3740,12 @@ class CollectionAPITest(TestCase):
             {'_id': 11, 'counts': {'circles': mongomock.ObjectId()}},
             # Document kept: datetimes are more than numbers.
             {'_id': 12, 'counts': {'circles': datetime.now()}},
+            # Document kept: BinData are more than numbers.
+            {'_id': 13, 'counts': {'circles': b'binary'}},
         ])
         results = collection.find(query)
-        self.assertEqual({1, 2, 5, 9, 11, 12}, {doc['_id'] for doc in results})
+        self.assertEqual(
+            {1, 2, 5, 9, 11, 12, 13}, {doc['_id'] for doc in results})
 
         query = {'counts': {'$gt': {'circles': re.compile('3')}}}
         self.assertFalse(list(collection.find(query)))

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -694,6 +694,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             {'_id': 8, 'counts': {}},
             {'_id': 9, 'counts': {'circles': 'three'}},
             {'_id': 10, 'counts': {'circles': None}},
+            {'_id': 11, 'counts': {'circles': b'bytes'}},
         ])
         self.cmp.compare_ignore_order.find({'counts': {'$gt': {'circles': 1}}})
 
@@ -817,7 +818,13 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.remove()
         for data in ({'a': 1},
                      {'a': 2, 'b': -2},
-                     {'a': 3, 'b': 4}):
+                     {'a': 3, 'b': 4},
+                     {'a': 4, 'b': b'bin1'},
+                     {'a': 4, 'b': b'bin2'},
+                     {'a': 4, 'b': b'alongbin1'},
+                     {'a': 4, 'b': b'alongbin2'},
+                     {'a': 4, 'b': b'zlongbin1'},
+                     {'a': 4, 'b': b'zlongbin2'}):
             self.cmp.do.insert(data)
         self.cmp.compare.find(sort=[('b', 1)])
         self.cmp.compare.find(sort=[('b', -1)])


### PR DESCRIPTION
I noticed i couldn't  sort operations on bytes field.

I do not know if the tests are enough, but this is a quite simple patch.