### PR TITLE
Support bson.regex on $not queries

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -136,7 +136,7 @@ class _Filterer(object):
             for key in s.keys():
                 if key not in self._operator_map and key not in LOGICAL_OPERATOR_MAP:
                     raise OperationFailure('unknown operator: %s' % key)
-        elif isinstance(s, type(re.compile(''))):
+        elif isinstance(s, _RE_TYPES):
             pass
         else:
             raise OperationFailure('$not needs a regex or a document')

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -29,6 +29,7 @@ except ImportError:
     _PYMONGO_VERSION = version.LooseVersion('0.0')
 try:
     from bson.code import Code
+    from bson.regex import Regex
     from bson.son import SON
     import execjs  # noqa pylint: disable=unused-import
     _HAVE_MAP_REDUCE = any(r.is_available() for r in execjs.runtimes().values())
@@ -651,6 +652,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find({'name': {'$not': {'$eq': 'dan'}}})
 
         self.cmp.compare_ignore_order.find({'name': {'$not': re.compile('dan')}})
+        self.cmp.compare_ignore_order.find({'name': {'$not': Regex('dan')}})
 
     def test__find_not_exceptions(self):
         self.cmp.do.insert(dict(noise='longhorn'))


### PR DESCRIPTION
For example: collection.find_one({"field": {"$not": Regex("^searchstr")}})

Issue #561
