### PR TITLE
collection.py: Fix return value of Collection.documents_count()

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1357,10 +1357,9 @@ class Collection(object):
         if unknown_kwargs:
             raise OperationFailure("unrecognized field '%s'" % unknown_kwargs.pop())
 
-        count = len(list(self._iter_documents(filter)))
-        if limit is None:
-            return count - skip
-        return min(count - skip, limit)
+        doc_num = len(list(self._iter_documents(filter)))
+        count = max(doc_num - skip, 0)
+        return count if limit is None else min(count, limit)
 
     def estimated_document_count(self, **kwargs):
         if kwargs.pop('session', None):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -360,6 +360,10 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.insert_one({'a': 0})
         self.cmp.compare.count_documents({})
         self.cmp.compare.count_documents({'a': 1})
+        self.cmp.compare.count_documents({}, skip=10)
+        self.cmp.compare.count_documents({}, skip=0)
+        self.cmp.compare.count_documents({}, skip=10, limit=100)
+        self.cmp.compare.count_documents({}, skip=10, limit=3)
 
     @skipIf(
         _PYMONGO_VERSION < version.LooseVersion('3.8'),


### PR DESCRIPTION
When skip was greater than count for
collection.Collection.document_count() the method kept returning
negative values It returns 0 now, which is the expected behaviour.

Fixes Issue #585 