### PR TITLE
Support for $slice operator in projection argument

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1037,7 +1037,7 @@ class Collection(object):
                     slice_ = None        
                     if isinstance(op_value, list):
                         if len(op_value) != 2:
-                            raise ValueError('Unsupported slice format {} for slicing operation: {}'.format(op_value, op))
+                            raise OperationFailure('Unsupported slice format {} for slicing operation: {}'.format(op_value, op))
                         skip = op_value[0]
                         limit = op_value[1]
                         if skip < 0:
@@ -1057,9 +1057,9 @@ class Collection(object):
                     if slice_:
                         doc_copy[field] = doc_copy[field][slice_]
                     else:
-                        raise ValueError('Unsupported slice value {} for slicing operation: {}'.format(op_value, op))
+                        raise OperationFailure('Unsupported slice value {} for slicing operation: {}'.format(op_value, op))
                 else:
-                    raise ValueError('Unsupported type {} for slicing operation: {}'.format(type(doc_copy[field]), op))
+                    raise OperationFailure('Unsupported type {} for slicing operation: {}'.format(type(doc_copy[field]), op))
 
             if '$elemMatch' in op:
                 if isinstance(doc_copy[field], list):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1038,7 +1038,8 @@ class Collection(object):
                     if isinstance(op_value, list):
                         if len(op_value) != 2:
                             raise OperationFailure(
-                                'Unsupported slice format {} for slicing operation: {}'.format(op_value, op))
+                                'Unsupported slice format {} for slicing operation: {}'.format(
+                                    op_value, op))
                         skip = op_value[0]
                         limit = op_value[1]
                         if skip < 0:
@@ -1059,10 +1060,12 @@ class Collection(object):
                         doc_copy[field] = doc_copy[field][slice_]
                     else:
                         raise OperationFailure(
-                            'Unsupported slice value {} for slicing operation: {}'.format(op_value, op))
+                            'Unsupported slice value {} for slicing operation: {}'.format(
+                                op_value, op))
                 else:
                     raise OperationFailure(
-                        'Unsupported type {} for slicing operation: {}'.format(type(doc_copy[field]), op))
+                        'Unsupported type {} for slicing operation: {}'.format(
+                            type(doc_copy[field]), op))
 
             if '$elemMatch' in op:
                 if isinstance(doc_copy[field], list):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1033,11 +1033,12 @@ class Collection(object):
 
             if '$slice' in op:
                 if isinstance(doc_copy[field], list):
-                    op_value = op['$slice']           
-                    slice_ = None        
+                    op_value = op['$slice']
+                    slice_ = None
                     if isinstance(op_value, list):
                         if len(op_value) != 2:
-                            raise OperationFailure('Unsupported slice format {} for slicing operation: {}'.format(op_value, op))
+                            raise OperationFailure(
+                                'Unsupported slice format {} for slicing operation: {}'.format(op_value, op))
                         skip = op_value[0]
                         limit = op_value[1]
                         if skip < 0:
@@ -1057,9 +1058,11 @@ class Collection(object):
                     if slice_:
                         doc_copy[field] = doc_copy[field][slice_]
                     else:
-                        raise OperationFailure('Unsupported slice value {} for slicing operation: {}'.format(op_value, op))
+                        raise OperationFailure(
+                            'Unsupported slice value {} for slicing operation: {}'.format(op_value, op))
                 else:
-                    raise OperationFailure('Unsupported type {} for slicing operation: {}'.format(type(doc_copy[field]), op))
+                    raise OperationFailure(
+                        'Unsupported type {} for slicing operation: {}'.format(type(doc_copy[field]), op))
 
             if '$elemMatch' in op:
                 if isinstance(doc_copy[field], list):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1041,7 +1041,7 @@ class Collection(object):
                         skip = op_value[0]
                         limit = op_value[1]
                         if skip < 0:
-                            skip = len(doc_copy[field]) - skip
+                            skip = len(doc_copy[field]) + skip
                         last = min(skip + limit, len(doc_copy[field]))
                         slice_ = slice(skip, last)
                     elif isinstance(op_value, int):
@@ -1049,10 +1049,10 @@ class Collection(object):
                         start = 0
                         end = len(doc_copy[field])
                         if count < 0:
-                            start = max(0, len(doc_copy[field]) - count)
+                            start = max(0, len(doc_copy[field]) + count)
                         else:
                             end = min(count, len(doc_copy[field]))
-                        slice_ = slice(skip, last)
+                        slice_ = slice(start, end)
 
                     if slice_:
                         doc_copy[field] = doc_copy[field][slice_]

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1032,40 +1032,38 @@ class Collection(object):
                     continue
 
             if '$slice' in op:
-                if isinstance(doc_copy[field], list):
-                    op_value = op['$slice']
-                    slice_ = None
-                    if isinstance(op_value, list):
-                        if len(op_value) != 2:
-                            raise OperationFailure(
-                                'Unsupported slice format {} for slicing operation: {}'.format(
-                                    op_value, op))
-                        skip = op_value[0]
-                        limit = op_value[1]
-                        if skip < 0:
-                            skip = len(doc_copy[field]) + skip
-                        last = min(skip + limit, len(doc_copy[field]))
-                        slice_ = slice(skip, last)
-                    elif isinstance(op_value, int):
-                        count = op_value
-                        start = 0
-                        end = len(doc_copy[field])
-                        if count < 0:
-                            start = max(0, len(doc_copy[field]) + count)
-                        else:
-                            end = min(count, len(doc_copy[field]))
-                        slice_ = slice(start, end)
-
-                    if slice_:
-                        doc_copy[field] = doc_copy[field][slice_]
-                    else:
-                        raise OperationFailure(
-                            'Unsupported slice value {} for slicing operation: {}'.format(
-                                op_value, op))
-                else:
+                if not isinstance(doc_copy[field], list):
                     raise OperationFailure(
                         'Unsupported type {} for slicing operation: {}'.format(
                             type(doc_copy[field]), op))
+                op_value = op['$slice']
+                slice_ = None
+                if isinstance(op_value, list):
+                    if len(op_value) != 2:
+                        raise OperationFailure(
+                            'Unsupported slice format {} for slicing operation: {}'.format(
+                                op_value, op))
+                    skip, limit = op_value
+                    if skip < 0:
+                        skip = len(doc_copy[field]) + skip
+                    last = min(skip + limit, len(doc_copy[field]))
+                    slice_ = slice(skip, last)
+                elif isinstance(op_value, int):
+                    count = op_value
+                    start = 0
+                    end = len(doc_copy[field])
+                    if count < 0:
+                        start = max(0, len(doc_copy[field]) + count)
+                    else:
+                        end = min(count, len(doc_copy[field]))
+                    slice_ = slice(start, end)
+
+                if slice_:
+                    doc_copy[field] = doc_copy[field][slice_]
+                else:
+                    raise OperationFailure(
+                        'Unsupported slice value {} for slicing operation: {}'.format(
+                            op_value, op))
 
             if '$elemMatch' in op:
                 if isinstance(doc_copy[field], list):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1012,9 +1012,19 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
     def test__projection_slice_list_pos(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
-                              'name': 1, 'values': {'$slice': [3, 10]}})
+                              'name': 1, 'values': {'$slice': [3, 1]}})
 
     def test__projection_slice_list_neg(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={
+                              'name': 1, 'values': {'$slice': [-3, 1]}})
+
+    def test__projection_slice_list_pos_to_end(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={
+                              'name': 1, 'values': {'$slice': [3, 10]}})
+
+    def test__projection_slice_list_neg_to_end(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
                               'name': 1, 'values': {'$slice': [-3, 10]}})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1029,6 +1029,12 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'name': 'Array'}, projection={
             'name': 1, 'values': {'$slice': [-3, 10]}})
 
+    def test__projection_slice_list_select_subfield(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [
+            {'num': 0, 'val': 1}, {'num': 1, 'val': 2}]})
+        self.cmp.compare.find({'name': 'Array'}, projection={
+            'values.num': 1, 'values': {'$slice': 1}})
+
     def test__projection_slice_list_wrong_num_slice(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         try:

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1001,6 +1001,22 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.insert({'name': 'Chucky', 'type': 'doll', 'model': 'v6'})
         self.cmp.compare_ignore_order.find({'name': 'Chucky'}, projection=[])
 
+    def test__projection_slice_int_first(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': 1}})
+
+    def test__projection_slice_int_last(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': -1}})
+
+    def test__projection_slice_list_pos(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [3,10]}})
+
+    def test__projection_slice_list_neg(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [-3,10]}})
+
     def test__remove(self):
         """Test the remove method."""
         self.cmp.do.insert({'value': 1})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1050,7 +1050,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
     def test__projection_slice_list_wrong_slice_value_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
-            'name': 1, 'values': {'$slice': "1"}})
+            'name': 1, 'values': {'$slice': '3'}})
 
     def test__projection_slice_list_wrong_value_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': 0})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1031,21 +1031,27 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__projection_slice_list_wrong_num_slice(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
-        with self.assertRaises(ValueError):
+        try:
             self.cmp.compare.find({'name': 'Array'}, projection={
                 'name': 1, 'values': {'$slice': [-3, 10, 1]}})
+        except Exception as e:
+            assert isinstance(e, mongomock.OperationFailure)
 
     def test__projection_slice_list_wrong_slice_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
-        with self.assertRaises(ValueError):
+        try:
             self.cmp.compare.find({'name': 'Array'}, projection={
                 'name': 1, 'values': {'$slice': [1.0]}})
+        except Exception as e:
+            assert isinstance(e, mongomock.OperationFailure)
 
     def test__projection_slice_list_wrong_value_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': 0})
-        with self.assertRaises(ValueError):
+        try:
             self.cmp.compare.find({'name': 'Array'}, projection={
                 'name': 1, 'values': {'$slice': 1}})
+        except Exception as e:
+            assert isinstance(e, mongomock.OperationFailure)
 
     def test__remove(self):
         """Test the remove method."""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1039,27 +1039,18 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__projection_slice_list_wrong_num_slice(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
-        try:
-            self.cmp.compare.find({'name': 'Array'}, projection={
-                'name': 1, 'values': {'$slice': [-3, 10, 1]}})
-        except Exception as e:
-            assert isinstance(e, mongomock.OperationFailure)
+        self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
+            'name': 1, 'values': {'$slice': [-3, 10, 1]}})
 
     def test__projection_slice_list_wrong_slice_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
-        try:
-            self.cmp.compare.find({'name': 'Array'}, projection={
-                'name': 1, 'values': {'$slice': [1.0]}})
-        except Exception as e:
-            assert isinstance(e, mongomock.OperationFailure)
+        self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
+            'name': 1, 'values': {'$slice': [1.0]}})
 
     def test__projection_slice_list_wrong_value_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': 0})
-        try:
-            self.cmp.compare.find({'name': 'Array'}, projection={
-                'name': 1, 'values': {'$slice': 1}})
-        except Exception as e:
-            assert isinstance(e, mongomock.OperationFailure)
+        self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
+            'name': 1, 'values': {'$slice': 1}})
 
     def test__remove(self):
         """Test the remove method."""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1002,20 +1002,22 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find({'name': 'Chucky'}, projection=[])
 
     def test__projection_slice_int_first(self):
-        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': 1}})
 
     def test__projection_slice_int_last(self):
-        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': -1}})
 
     def test__projection_slice_list_pos(self):
-        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
-        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [3, 10]}})
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={
+                              'name': 1, 'values': {'$slice': [3, 10]}})
 
     def test__projection_slice_list_neg(self):
-        self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
-        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [-3, 10]}})
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        self.cmp.compare.find({'name': 'Array'}, projection={
+                              'name': 1, 'values': {'$slice': [-3, 10]}})
 
     def test__remove(self):
         """Test the remove method."""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1029,6 +1029,18 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'name': 'Array'}, projection={
                               'name': 1, 'values': {'$slice': [-3, 10]}})
 
+    def test__projection_slice_list_wrong_num_slice(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        with self.assertRaises(ValueError):
+            self.cmp.compare.find({'name': 'Array'}, projection={
+                'name': 1, 'values': {'$slice': [-3, 10, 1]}})
+
+    def test__projection_slice_list_wrong_type(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        with self.assertRaises(ValueError):
+            self.cmp.compare.find({'name': 'Array'}, projection={
+                'name': 1, 'values': {'$slice': [1.0]}})
+
     def test__remove(self):
         """Test the remove method."""
         self.cmp.do.insert({'value': 1})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1011,11 +1011,11 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__projection_slice_list_pos(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
-        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [3,10]}})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [3, 10]}})
 
     def test__projection_slice_list_neg(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0,1,2,3,4,5,6,7]})
-        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [-3,10]}})
+        self.cmp.compare.find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [-3, 10]}})
 
     def test__remove(self):
         """Test the remove method."""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1035,11 +1035,17 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             self.cmp.compare.find({'name': 'Array'}, projection={
                 'name': 1, 'values': {'$slice': [-3, 10, 1]}})
 
-    def test__projection_slice_list_wrong_type(self):
+    def test__projection_slice_list_wrong_slice_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         with self.assertRaises(ValueError):
             self.cmp.compare.find({'name': 'Array'}, projection={
                 'name': 1, 'values': {'$slice': [1.0]}})
+
+    def test__projection_slice_list_wrong_value_type(self):
+        self.cmp.do.insert({'name': 'Array', 'values': 0})
+        with self.assertRaises(ValueError):
+            self.cmp.compare.find({'name': 'Array'}, projection={
+                'name': 1, 'values': {'$slice': 1}})
 
     def test__remove(self):
         """Test the remove method."""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1047,6 +1047,11 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
             'name': 1, 'values': {'$slice': [1.0]}})
 
+    def test__projection_slice_list_wrong_slice_value_type(self):
+        self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
+        self.cmp.compare_exceptions.find({'name': 'Array'}, projection={
+            'name': 1, 'values': {'$slice': "1"}})
+
     def test__projection_slice_list_wrong_value_type(self):
         self.cmp.do.insert({'name': 'Array', 'values': 0})
         self.cmp.compare_exceptions.find({'name': 'Array'}, projection={

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1012,22 +1012,22 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
     def test__projection_slice_list_pos(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
-                              'name': 1, 'values': {'$slice': [3, 1]}})
+            'name': 1, 'values': {'$slice': [3, 1]}})
 
     def test__projection_slice_list_neg(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
-                              'name': 1, 'values': {'$slice': [-3, 1]}})
+            'name': 1, 'values': {'$slice': [-3, 1]}})
 
     def test__projection_slice_list_pos_to_end(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
-                              'name': 1, 'values': {'$slice': [3, 10]}})
+            'name': 1, 'values': {'$slice': [3, 10]}})
 
     def test__projection_slice_list_neg_to_end(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})
         self.cmp.compare.find({'name': 'Array'}, projection={
-                              'name': 1, 'values': {'$slice': [-3, 10]}})
+            'name': 1, 'values': {'$slice': [-3, 10]}})
 
     def test__projection_slice_list_wrong_num_slice(self):
         self.cmp.do.insert({'name': 'Array', 'values': [0, 1, 2, 3, 4, 5, 6, 7]})


### PR DESCRIPTION
Hi,

I've added support for lists slicing in the projection argument. Like that:
find({'name': 'Array'}, projection={'name': 1, 'values': {'$slice': [-3, 10]}}
[Mongodb documentation](https://docs.mongodb.com/manual/reference/operator/projection/slice/)

Please, review and approve :-)