### PR TITLE
Allow $all to be specified alongside other operators

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -100,7 +100,9 @@ class _Filterer(object):
             if isinstance(search, dict) and '$all' in search:
                 if not self._all_op(iter_key_candidates(key, document), search['$all']):
                     return False
-                continue
+                # if there are no query operators then continue
+                if len(search) == 1:
+                    continue
 
             for doc_val in iter_key_candidates(key, document):
                 has_candidates |= doc_val is not NOTHING

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -471,6 +471,15 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'_id': id, 'l_string': {'$not': {'$size': 0}}})
         self.cmp.compare.find({'_id': id, 'l_tuple': {'$size': 2}})
 
+    def test__size_with_all(self):
+        objs = [{'list': ['a']}, {'list': ['a', 123]}, {'list': ['a', 123, 'xyz']}]
+        self.cmp.do.insert_many(objs)
+        self.cmp.compare.find({'list': {'$all': ['a']}})
+        self.cmp.compare.find({'list': {'$all': ['a', 123]}})
+        self.cmp.compare.find({'list': {'$all': ['a'], '$size': 1}})
+        self.cmp.compare.find({'list': {'$all': ['a', 123], '$size': 2}})
+        self.cmp.compare.find({'list': {'$all': ['a', 123, 'xyz'], '$size': 3}})
+
     def test__regex_match_non_string(self):
         id = ObjectId()
         self.cmp.do.insert({

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -471,14 +471,16 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'_id': id, 'l_string': {'$not': {'$size': 0}}})
         self.cmp.compare.find({'_id': id, 'l_tuple': {'$size': 2}})
 
-    def test__size_with_all(self):
+    def test__all_with_other_operators(self):
         objs = [{'list': ['a']}, {'list': ['a', 123]}, {'list': ['a', 123, 'xyz']}]
         self.cmp.do.insert_many(objs)
-        self.cmp.compare.find({'list': {'$all': ['a']}})
-        self.cmp.compare.find({'list': {'$all': ['a', 123]}})
         self.cmp.compare.find({'list': {'$all': ['a'], '$size': 1}})
         self.cmp.compare.find({'list': {'$all': ['a', 123], '$size': 2}})
         self.cmp.compare.find({'list': {'$all': ['a', 123, 'xyz'], '$size': 3}})
+        self.cmp.compare.find({'list': {'$all': ['a'], '$size': 3}})
+        self.cmp.compare.find({'list': {'$all': ['a', 123], '$in': ['xyz']}})
+        self.cmp.compare.find({'list': {'$all': ['a', 123, 'xyz'], '$in': ['abcdef']}})
+        self.cmp.compare.find({'list': {'$all': ['a'], '$eq': ['a']}})
 
     def test__regex_match_non_string(self):
         id = ObjectId()


### PR DESCRIPTION
Previously `$all` would silently skip any other operators being used, except `$elemMatch` which is implemented explicitly inside the `_all_op` operator. This PR adds support for using other operators, e.g. `$size`, in conjunction with `$all` by preventing the skipping over other keys if they are present.

I've tested for a few possible unforeseen consequences, but cannot trigger any behavior that does not match pymongo.

EDIT: this would hopefully close #594 