### PR TITLE
Drop the test database rather than the test collection

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -243,7 +243,7 @@ class _CollectionComparisonTest(TestCase):
         self.mongo_conn = self._connect_to_local_mongodb()
         self.db_name = 'mongomock___testing_db'
         self.collection_name = 'mongomock___testing_collection'
-        self.mongo_conn[self.db_name][self.collection_name].drop()
+        self.mongo_conn.drop_database(self.db_name)
         self.mongo_collection = self.mongo_conn[self.db_name][self.collection_name]
         self.fake_collection = self.fake_conn[self.db_name][self.collection_name]
         self.cmp = MultiCollection({


### PR DESCRIPTION
Since one of the tests rename a collection (test__rename_collection) and nothing cleans it up, this test fails on the second run (`pymongo.errors.OperationFailure: target namespace exists`).