### PR TITLE
Project missing fields in a nested dict fix

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -980,7 +980,7 @@ def _handle_project_stage(in_collection, unused_database, options):
 
         for in_doc, out_doc in zip(in_collection, new_fields_collection):
             try:
-                out_doc[field] = _parse_expression(value, in_doc)
+                out_doc[field] = _parse_expression(value, in_doc, ignore_missing_keys=True)
             except KeyError:
                 pass
     if (method == 'include') == (include_id is not False and include_id is not 0):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -3068,6 +3068,17 @@ class CollectionAPITest(TestCase):
         ])
         self.assertEqual([{}], list(actual))
 
+    def test__aggregate_project_missing_nested_fields(self):
+        self.db.collection.insert_one({'_id': 1, 'a': 2, 'b': {'c': 1}})
+        actual = self.db.collection.aggregate([
+            {'$match': {'_id': 1}},
+            {'$project': collections.OrderedDict([
+                ('_id', False),
+                ('nested_dictionary', {'c': '$b.c', 'd': '$b.d'})
+            ])}
+        ])
+        self.assertEqual([{'nested_dictionary': {'c': 1}}], list(actual))
+
     def test__aggregate_project_out(self):
         self.db.collection.insert_one({'_id': 1, 'arr': {'a': 2, 'b': 3}})
         self.db.collection.insert_one({'_id': 2, 'arr': {'a': 4, 'b': 5}})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2239,6 +2239,19 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         ]
         self.cmp.compare_ignore_order.aggregate(pipeline)
 
+    def test_aggregate_project_with_missing_subfields(self):
+        self.cmp.do.insert_many([
+            {'a': {'b': 3}, 'other': 1},
+            {'a': {'b': {'c': 4}, 'd': 5}},
+            {'a': {'c': 3, 'd': 5}},
+            {'b': {'c': 3}},
+            {'a': 5},
+        ])
+        pipeline = [
+            {'$project': {'_id': False, 'e': '$a.b.c'}}
+        ]
+        self.cmp.compare_ignore_order.aggregate(pipeline)
+
     def test__aggregate_unwind_project_id(self):
         self.cmp.do.insert_one({
             '_id': 'id0',


### PR DESCRIPTION
Current behavior of mongomock is "Ignore the whole dictionary if we couldn't find a single key"

That's not what the real mongo does

The real mongo just ignores this missing key
```
> db.asdf.aggregate([{'$project': {'a': 1, 'b': {'c': '$b'}}}])
{ "_id" : ObjectId("5e6875c3c3b830d2aaf259e5"), "a" : 1, "b" : {  } }
```