### PR TITLE
Add $toDecimal operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ flycheck-*
 
 ### vim
 .ropeproject/
+
+### env path
+/env/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ flycheck-*
 
 ### vim
 .ropeproject/
-
-### env path
-/env/

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -500,8 +500,12 @@ class _Parser(object):
             if isinstance(parsed, bool):
                 parsed = '1' if parsed is True else '0'
                 decimal_value = decimal128.Decimal128(parsed)
-            elif isinstance(parsed, float) or isinstance(parsed, int):
+            elif isinstance(parsed, int):
                 decimal_value = decimal128.Decimal128(str(parsed))
+            elif isinstance(parsed, float):
+                exp = decimal.Decimal('.00000000000000')
+                decimal_value = decimal.Decimal(str(parsed)).quantize(exp)
+                decimal_value = decimal128.Decimal128(decimal_value)
             elif isinstance(parsed, decimal128.Decimal128):
                 decimal_value = parsed
             elif isinstance(parsed, str):
@@ -513,10 +517,11 @@ class _Parser(object):
                         'Failed to parse string to decimal' % parsed)
             elif isinstance(parsed, datetime.datetime):
                 epoch = datetime.datetime.utcfromtimestamp(0)
-                decimal_value = decimal128.Decimal128(str((parsed - epoch).total_seconds() * 1000))
+                string_micro_seconds = str((parsed - epoch).total_seconds() * 1000).split('.')[0]
+                decimal_value = decimal128.Decimal128(string_micro_seconds)
             else:
                 raise TypeError(" '%s' type is not supported" % type(parsed))
-            return decimal_value.to_decimal()
+            return decimal_value
 
     def _handle_conditional_operator(self, operator, values):
         if operator == '$ifNull':

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -4,6 +4,7 @@ import bisect
 import collections
 import copy
 import datetime
+import decimal
 import itertools
 import math
 import numbers
@@ -496,18 +497,17 @@ class _Parser(object):
                     'You need to import the pymongo library to support decimal128 type.'
                 )
             parsed = self.parse(values)
-            decimal_value = None
             if isinstance(parsed, bool):
-                parsed = '0' if parsed is True else '1'
+                parsed = '1' if parsed is True else '0'
                 decimal_value = decimal128.Decimal128(parsed)
             elif isinstance(parsed, float) or isinstance(parsed, int):
                 decimal_value = decimal128.Decimal128(str(parsed))
             elif isinstance(parsed, decimal128.Decimal128):
                 decimal_value = parsed
             elif isinstance(parsed, str):
-                if parsed.isdigit():
+                try:
                     decimal_value = decimal128.Decimal128(parsed)
-                else:
+                except decimal.InvalidOperation:
                     raise OperationFailure(
                         "Failed to parse number '%s' in $convert with no onError value:"
                         'Failed to parse string to decimal' % parsed)

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -520,7 +520,7 @@ class _Parser(object):
                 string_micro_seconds = str((parsed - epoch).total_seconds() * 1000).split('.')[0]
                 decimal_value = decimal128.Decimal128(string_micro_seconds)
             else:
-                raise TypeError(" '%s' type is not supported" % type(parsed))
+                raise TypeError("'%s' type is not supported" % type(parsed))
             return decimal_value
 
     def _handle_conditional_operator(self, operator, values):

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -1,6 +1,14 @@
 import datetime
+import decimal
 from platform import python_version
+
 from six import integer_types, string_types, text_type
+
+try:
+    from bson import decimal128
+    _HAVE_PYMONGO = True
+except ImportError:
+    _HAVE_PYMONGO = False
 
 
 class _NO_VALUE(object):
@@ -10,8 +18,13 @@ class _NO_VALUE(object):
 # we don't use NOTHING because it might be returned from various APIs
 NO_VALUE = _NO_VALUE()
 
-_SUPPORTED_TYPES = (float, bool, str, datetime.datetime, type(None)) + \
+_SUPPORTED_BASE_TYPES = (float, bool, str, datetime.datetime, type(None)) + \
     string_types + integer_types + (text_type, bytes) + (type,)
+
+if _HAVE_PYMONGO:
+    _SUPPORTED_TYPES = _SUPPORTED_BASE_TYPES + (decimal.Decimal, decimal128.Decimal128)
+else:
+    _SUPPORTED_TYPES = _SUPPORTED_BASE_TYPES
 
 if python_version() < '3.0':
     dict_type = dict

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4842,6 +4842,8 @@ class CollectionAPITest(TestCase):
             'double': 1.999,
             'decimal': decimal128.Decimal128('5.5000'),
             'str_base_10_numeric': '123',
+            'str_negative_number': '-23',
+            'str_decimal_number': '1.99',
             'str_not_numeric': '123a123',
             'datetime': datetime.utcfromtimestamp(0),
         })
@@ -4855,6 +4857,8 @@ class CollectionAPITest(TestCase):
                         'double': {'$toDecimal': '$double'},
                         'decimal': {'$toDecimal': '$decimal'},
                         'str_base_10_numeric': {'$toDecimal': '$str_base_10_numeric'},
+                        'str_negative_number': {'$toDecimal': '$str_negative_number'},
+                        'str_decimal_number': {'$toDecimal': '$str_decimal_number'},
                         'datetime': {'$toDecimal': '$datetime'},
                     }
                 },
@@ -4866,12 +4870,14 @@ class CollectionAPITest(TestCase):
             ]
         )
         expect = [{
-            'boolean_true': decimal128.Decimal128('0').to_decimal(),
-            'boolean_false': decimal128.Decimal128('1').to_decimal(),
+            'boolean_true': decimal128.Decimal128('1').to_decimal(),
+            'boolean_false': decimal128.Decimal128('0').to_decimal(),
             'integer': decimal128.Decimal128('100').to_decimal(),
             'double': decimal128.Decimal128('1.999').to_decimal(),
             'decimal': decimal128.Decimal128('5.5000').to_decimal(),
             'str_base_10_numeric': decimal128.Decimal128('123').to_decimal(),
+            'str_negative_number': decimal128.Decimal128('-23').to_decimal(),
+            'str_decimal_number': decimal128.Decimal128('1.99').to_decimal(),
             'str_not_numeric': '123a123',
             'datetime': decimal128.Decimal128('0.0').to_decimal(),
         }]

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4870,16 +4870,16 @@ class CollectionAPITest(TestCase):
             ]
         )
         expect = [{
-            'boolean_true': decimal128.Decimal128('1').to_decimal(),
-            'boolean_false': decimal128.Decimal128('0').to_decimal(),
-            'integer': decimal128.Decimal128('100').to_decimal(),
-            'double': decimal128.Decimal128('1.999').to_decimal(),
-            'decimal': decimal128.Decimal128('5.5000').to_decimal(),
-            'str_base_10_numeric': decimal128.Decimal128('123').to_decimal(),
-            'str_negative_number': decimal128.Decimal128('-23').to_decimal(),
-            'str_decimal_number': decimal128.Decimal128('1.99').to_decimal(),
+            'boolean_true': decimal128.Decimal128('1'),
+            'boolean_false': decimal128.Decimal128('0'),
+            'integer': decimal128.Decimal128('100'),
+            'double': decimal128.Decimal128('1.99900000000000'),
+            'decimal': decimal128.Decimal128('5.5000'),
+            'str_base_10_numeric': decimal128.Decimal128('123'),
+            'str_negative_number': decimal128.Decimal128('-23'),
+            'str_decimal_number': decimal128.Decimal128('1.99'),
             'str_not_numeric': '123a123',
-            'datetime': decimal128.Decimal128('0.0').to_decimal(),
+            'datetime': decimal128.Decimal128('0'),
         }]
         self.assertEqual(expect, list(actual))
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4914,6 +4914,30 @@ class CollectionAPITest(TestCase):
                 ]
             )
 
+    @skipIf(_HAVE_PYMONGO, 'pymongo installed')
+    def test__aggregate_to_decimal_without_pymongo(self):
+        collection = self.db.collection
+        collection.insert_one({
+            'boolean_true': True,
+            'boolean_false': False,
+        })
+        with self.assertRaises(NotImplementedError):
+            collection.aggregate(
+                [
+                    {
+                        '$addFields': {
+                            'boolean_true': {'$toDecimal': '$boolean_true'},
+                            'boolean_false': {'$toDecimal': '$boolean_false'},
+                        }
+                    },
+                    {
+                        '$project': {
+                            '_id': 0
+                        }
+                    }
+                ]
+            )
+
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__aggregate_to_int(self):
         collection = self.db.collection

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2927,7 +2927,6 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
     def test__aggregate_to_decimal(self):
         self.cmp.do.drop()
         self.cmp.do.insert_one({
-            '_id': ObjectId('5dd6a8f302c91829ef248161'),
             'boolean_true': True,
             'boolean_false': False,
             'integer': 100,

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2924,6 +2924,39 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         ]
         self.cmp.compare.aggregate(pipeline)
 
+    def test__aggregate_to_decimal(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            '_id': ObjectId('5dd6a8f302c91829ef248161'),
+            'boolean_true': True,
+            'boolean_false': False,
+            'integer': 100,
+            'double': 1.999,
+            'decimal': decimal128.Decimal128('5.5000'),
+            'str_base_10_numeric': '123',
+            'str_negative_number': '-23',
+            'str_decimal_number': '1.99',
+            'str_not_numeric': '123a123',
+            'datetime': datetime.datetime.utcfromtimestamp(0),
+        })
+        pipeline = [
+            {
+                '$addFields': {
+                    'boolean_true': {'$toDecimal': '$boolean_true'},
+                    'boolean_false': {'$toDecimal': '$boolean_false'},
+                    'integer': {'$toDecimal': '$integer'},
+                    'double': {'$toDecimal': '$double'},
+                    'decimal': {'$toDecimal': '$decimal'},
+                    'str_base_10_numeric': {'$toDecimal': '$str_base_10_numeric'},
+                    'str_negative_number': {'$toDecimal': '$str_negative_number'},
+                    'str_decimal_number': {'$toDecimal': '$str_decimal_number'},
+                    'datetime': {'$toDecimal': '$datetime'},
+                }
+            },
+            {'$project': {'_id': 0}},
+        ]
+        self.cmp.compare.aggregate(pipeline)
+
     def test_aggregate_to_int(self):
         self.cmp.do.drop()
         self.cmp.do.insert_one({


### PR DESCRIPTION
Hi everyone,
I just fully implemented $toDecimal operator of aggregation convertor with UTs.
The original  behaviors of $toDecimal can be found in [https://docs.mongodb.com/manual/reference/operator/aggregation/toDecimal/#behavior](url)

There is one behavior that doesn't have error detail in document is

> You cannot convert a string value of a non-base10 number (e.g. "0x6400")

After I check the real error from MongoDB, I confirm it will raise a OperationFailure with detail. I also implement it with a UT.

If it's convenient, would you like to check and merge this request. 

PS： I may found a bug in the base function `_Parse` when I wrote tests. I will open an issue for it later.

Cheers!