### PR TITLE
Fix the not exist case in $toInt and $toDecimal

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -481,7 +481,10 @@ class _Parser(object):
             return str(parsed)
 
         if operator == '$toInt':
-            parsed = self.parse(values)
+            try:
+                parsed = self.parse(values)
+            except KeyError:
+                return None
             if decimal_support:
                 if isinstance(parsed, decimal128.Decimal128):
                     return int(parsed.to_decimal())
@@ -496,7 +499,10 @@ class _Parser(object):
                 raise NotImplementedError(
                     'You need to import the pymongo library to support decimal128 type.'
                 )
-            parsed = self.parse(values)
+            try:
+                parsed = self.parse(values)
+            except KeyError:
+                return None
             if isinstance(parsed, bool):
                 parsed = '1' if parsed is True else '0'
                 decimal_value = decimal128.Decimal128(parsed)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4860,6 +4860,7 @@ class CollectionAPITest(TestCase):
                         'str_negative_number': {'$toDecimal': '$str_negative_number'},
                         'str_decimal_number': {'$toDecimal': '$str_decimal_number'},
                         'datetime': {'$toDecimal': '$datetime'},
+                        'not_exist_field': {'$toDecimal': '$not_exist_field'},
                     }
                 },
                 {
@@ -4880,6 +4881,7 @@ class CollectionAPITest(TestCase):
             'str_decimal_number': decimal128.Decimal128('1.99'),
             'str_not_numeric': '123a123',
             'datetime': decimal128.Decimal128('0'),
+            'not_exist_field': None,
         }]
         self.assertEqual(expect, list(actual))
 
@@ -4956,7 +4958,8 @@ class CollectionAPITest(TestCase):
                         'boolean_false': {'$toInt': '$boolean_false'},
                         'integer': {'$toInt': '$integer'},
                         'double': {'$toInt': '$double'},
-                        'decimal': {'$toInt': '$decimal'}
+                        'decimal': {'$toInt': '$decimal'},
+                        'not_exist': {'$toInt': '$not_exist'},
                     }
                 },
                 {
@@ -4972,7 +4975,8 @@ class CollectionAPITest(TestCase):
             'boolean_false': 0,
             'integer': 100,
             'double': 1,
-            'decimal': 5
+            'decimal': 5,
+            'not_exist': None,
         }]
         self.assertEqual(expect, list(actual))
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2950,6 +2950,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
                     'str_negative_number': {'$toDecimal': '$str_negative_number'},
                     'str_decimal_number': {'$toDecimal': '$str_decimal_number'},
                     'datetime': {'$toDecimal': '$datetime'},
+                    'not_exist_field': {'$toDecimal': '$not_exist_field'},
                 }
             },
             {'$project': {'_id': 0}},
@@ -2972,7 +2973,8 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
                     'boolean_false': {'$toInt': '$boolean_false'},
                     'integer': {'$toInt': '$integer'},
                     'double': {'$toInt': '$double'},
-                    'decimal': {'$toInt': '$decimal'}
+                    'decimal': {'$toInt': '$decimal'},
+                    'not_exist': {'$toInt': '$not_exist'},
                 }
             },
             {


### PR DESCRIPTION
It's the fix for the bug I mentioned in the last PR. 

First, I thought it was a serious bug in `_Parse` function, so I haven't fix it in the last PR. Now, I believe it only affect the operators in the `$addField` operator. So, I fix them in this PR with UTs.

The case is, when we try to add a field from a field which is not exist, Mongo will return the new field with the value of None.

Now, the `$toInt` and `$toDecimal` operators will return the original query now. So I return None when the `KeyError` raised in these operators.

If you're convenient, please review and merge it. 

Cheers! 