### PR TITLE
Support sum decimal type of values in $sum operator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,7 @@ Also, many thanks go to the following people for helping out, contributing pull 
 * Srinivas Reddy Thatiparthy
 * Taras Boiko
 * Todd Tomkinson
+* `Xinyan Lu <https://github.com/lxy1992/>`_
 * Zachary Carter
 * catty (ca77y _at_ live.com)
 * emosenkis

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -134,8 +134,22 @@ def _group_operation(values, operator):
     return operator(values_list)
 
 
+def _sum_operation(values):
+    values_list = list()
+    if decimal_support:
+        for v in values:
+            if isinstance(v, numbers.Number):
+                values_list.append(v)
+            elif isinstance(v, decimal128.Decimal128):
+                values_list.append(v.to_decimal())
+    else:
+        values_list = list(v for v in values if isinstance(v, numbers.Number))
+    sum_value = sum(values_list)
+    return decimal128.Decimal128(sum_value) if isinstance(sum_value, decimal.Decimal) else sum_value
+
+
 _GROUPING_OPERATOR_MAP = {
-    '$sum': lambda values: sum(v for v in values if isinstance(v, numbers.Number)),
+    '$sum': _sum_operation,
     '$avg': _avg_operation,
     '$min': lambda values: _group_operation(values, min),
     '$max': lambda values: _group_operation(values, max),

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2514,6 +2514,22 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         }}]
         self.cmp.compare.aggregate(pipeline)
 
+    def test__aggregate35(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            '_id': 1,
+            'a': 2,
+            'b': 3,
+            'c': '$d',
+            'd': decimal128.Decimal128('4')
+        })
+        pipeline = [{'$project': {
+            '_id': 0,
+            'sum': {'$sum': [4, 2, None, 3, '$a', '$b', '$d', {'$sum': [0, 1, '$b']}]},
+            'sumNone': {'$sum': ['a', None]},
+        }}]
+        self.cmp.compare.aggregate(pipeline)
+
     def test__aggregate_project_id_0(self):
         self.cmp.do.remove()
         self.cmp.do.insert([


### PR DESCRIPTION
This PR add the support for the decimal value in `$sum` operator with UTs

Behavior:
* any value in the list of `$sum` operator is `decimal128.Decimal`, the result of sum will be `decimal128.Decimal128`.

The mongo support all types in `numbers.Number`, the `decimal` is one of them. However, the real type of decimal mongo store in the disk is `decimal128.Decimal128`, which is not supported by the `sum` function in Python. So, I convert them to `decimal.Decimal` before sum, revert the type of result when return.

Looking forwarding to code review.

Cheers!
