### PR TITLE
improve aggregation expression parsing

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -303,7 +303,7 @@ class _Parser(object):
                 return helpers.get_value_by_dot(dict({
                     'ROOT': self._doc_dict,
                     'CURRENT': self._doc_dict,
-                }, **self._user_vars), expression[2:])
+                }, **self._user_vars), expression[2:], can_generate_array=True)
             return helpers.get_value_by_dot(self._doc_dict, expression[1:], can_generate_array=True)
         return expression
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2097,6 +2097,14 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             function(cur, result) { result.count += cur.count }
         '''))
 
+    def test__aggregate_system_variables_generate_array(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one(
+            {'name': 'foo', 'errors': [
+                {'error_type': 1, 'description': 'problem 1'},
+                {'error_type': 2, 'description': 'problem 2'}]})
+        self.cmp.compare.aggregate([{'$project': {'error_type': '$$ROOT.errors.error_type'}}])
+
 
 @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
 @skipIf(not _HAVE_MAP_REDUCE, 'execjs not installed')


### PR DESCRIPTION
Make expressions starting with `$$ROOT` or `$$CURRENT` work on documents with array of embedded documents fields.
Consider the following document dict:
```{'name': 'foo', 'errors': [{'error_type': 1, 'description': 'problem 1'}, {'error_type': 2, 'description': 'problem 2'}], '_id': ObjectId('5e8c9ac81e957db62b16b888')}```
And the expression - `$$ROOT.errors.error_type`
Current code will throw KeyError exception - `{KeyError}2`