### PR TITLE
Add support for read concern

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -62,9 +62,9 @@ from mongomock.results import BulkWriteResult
 from mongomock.results import DeleteResult
 from mongomock.results import InsertManyResult
 from mongomock.results import InsertOneResult
+from mongomock.read_concern import ReadConcern
 from mongomock.results import UpdateResult
 from mongomock.write_concern import WriteConcern
-from mongomock.read_concern import ReadConcern
 from mongomock import WriteError
 
 if hasattr(time, 'perf_counter'):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -58,11 +58,11 @@ from mongomock import helpers
 from mongomock import InvalidOperation
 from mongomock import ObjectId
 from mongomock import OperationFailure
+from mongomock.read_concern import ReadConcern
 from mongomock.results import BulkWriteResult
 from mongomock.results import DeleteResult
 from mongomock.results import InsertManyResult
 from mongomock.results import InsertOneResult
-from mongomock.read_concern import ReadConcern
 from mongomock.results import UpdateResult
 from mongomock.write_concern import WriteConcern
 from mongomock import WriteError

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -97,7 +97,7 @@ class Database(object):
         except KeyError:
             self._ensure_valid_collection_name(name)
             collection = self._collection_accesses[name] = Collection(
-                self, name=name, write_concern=write_concern,
+                self, name=name, read_concern=read_concern, write_concern=write_concern,
                 read_preference=read_preference or self.read_preference,
                 codec_options=codec_options or self._codec_options, _db_store=self._store, )
             return collection

--- a/mongomock/read_concern.py
+++ b/mongomock/read_concern.py
@@ -1,0 +1,23 @@
+class ReadConcern(object):
+    def __init__(self, level=None):
+        self._document = {}
+
+        if level is not None:
+            self._document['level'] = level
+
+    @property
+    def level(self):
+        return self._document.get('level')
+
+    @property
+    def ok_for_legacy(self):
+        return True
+
+    @property
+    def document(self):
+        return self._document.copy()
+
+    def __eq__(self, other):
+        if isinstance(other, ReadConcern):
+            return self.document == other.document
+        return NotImplemented

--- a/mongomock/read_concern.py
+++ b/mongomock/read_concern.py
@@ -18,6 +18,4 @@ class ReadConcern(object):
         return self._document.copy()
 
     def __eq__(self, other):
-        if isinstance(other, ReadConcern):
-            return self.document == other.document
-        return NotImplemented
+        return other.document == self.document

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -30,8 +30,8 @@ try:
     _HAVE_PYMONGO = True
 except ImportError:
     from mongomock.collection import ReturnDocument
-    from mongomock.read_concern import ReadConcern
     from mongomock import ObjectId
+    from mongomock.read_concern import ReadConcern
     from mongomock.write_concern import WriteConcern
 
     _HAVE_PYMONGO = False

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -22,17 +22,17 @@ try:
     from bson import tz_util, ObjectId, Regex, decimal128, Timestamp
     import pymongo
     from pymongo.collation import Collation
+    from pymongo.read_concern import ReadConcern
     from pymongo.read_preferences import ReadPreference
     from pymongo import ReturnDocument
-    from pymongo.read_concern import ReadConcern
     from pymongo.write_concern import WriteConcern
 
     _HAVE_PYMONGO = True
 except ImportError:
+    from mongomock.read_concern import ReadConcern
     from mongomock.collection import ReturnDocument
     from mongomock import ObjectId
     from mongomock.write_concern import WriteConcern
-    from mongomock.read_concern import ReadConcern
 
     _HAVE_PYMONGO = False
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -31,6 +31,7 @@ except ImportError:
     from mongomock.collection import ReturnDocument
     from mongomock import ObjectId
     from mongomock.write_concern import WriteConcern
+    from mongomock.read_concern import ReadConcern
 
     _HAVE_PYMONGO = False
 
@@ -1833,6 +1834,8 @@ class CollectionAPITest(TestCase):
         self.db.collection.with_options(read_preference=None)
         self.db.collection.with_options(write_concern=self.db.collection.write_concern)
         self.db.collection.with_options(write_concern=WriteConcern(w=1))
+        self.db.collection.with_options(read_concern=self.db.collection.read_concern)
+        self.db.collection.with_options(read_concern=ReadConcern(level='local'))
 
     def test__with_options_different_write_concern(self):
         self.db.collection.insert_one({'name': 'col1'})
@@ -1847,6 +1850,20 @@ class CollectionAPITest(TestCase):
         self.assertEqual({}, self.db.collection.write_concern.document)
         self.assertNotEqual(self.db.collection.write_concern, col2.write_concern)
         self.assertEqual({'w': 2}, col2.write_concern.document)
+
+    def test__with_options_different_write_readconcern(self):
+        self.db.collection.insert_one({'name': 'col1'})
+        col2 = self.db.collection.with_options(read_concern=ReadConcern(level='majority'))
+        col2.insert_one({'name': 'col2'})
+
+        # Check that the two objects have the same data.
+        self.assertEqual({'col1', 'col2'}, {d['name'] for d in self.db.collection.find()})
+        self.assertEqual({'col1', 'col2'}, {d['name'] for d in col2.find()})
+
+        # Check that each object has its own write concern.
+        self.assertEqual({}, self.db.collection.read_concern.document)
+        self.assertNotEqual(self.db.collection.read_concern, col2.read_concern)
+        self.assertEqual({'level': 'majority'}, col2.read_concern.document)
 
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__with_options_different_read_preference(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -29,8 +29,8 @@ try:
 
     _HAVE_PYMONGO = True
 except ImportError:
-    from mongomock.read_concern import ReadConcern
     from mongomock.collection import ReturnDocument
+    from mongomock.read_concern import ReadConcern
     from mongomock import ObjectId
     from mongomock.write_concern import WriteConcern
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -24,6 +24,7 @@ try:
     from pymongo.collation import Collation
     from pymongo.read_preferences import ReadPreference
     from pymongo import ReturnDocument
+    from pymongo.read_concern import ReadConcern
     from pymongo.write_concern import WriteConcern
 
     _HAVE_PYMONGO = True
@@ -1851,7 +1852,7 @@ class CollectionAPITest(TestCase):
         self.assertNotEqual(self.db.collection.write_concern, col2.write_concern)
         self.assertEqual({'w': 2}, col2.write_concern.document)
 
-    def test__with_options_different_write_readconcern(self):
+    def test__with_options_different_read_concern(self):
         self.db.collection.insert_one({'name': 'col1'})
         col2 = self.db.collection.with_options(read_concern=ReadConcern(level='majority'))
         col2.insert_one({'name': 'col2'})
@@ -1860,7 +1861,7 @@ class CollectionAPITest(TestCase):
         self.assertEqual({'col1', 'col2'}, {d['name'] for d in self.db.collection.find()})
         self.assertEqual({'col1', 'col2'}, {d['name'] for d in col2.find()})
 
-        # Check that each object has its own write concern.
+        # Check that each object has its own read concern.
         self.assertEqual({}, self.db.collection.read_concern.document)
         self.assertNotEqual(self.db.collection.read_concern, col2.read_concern)
         self.assertEqual({'level': 'majority'}, col2.read_concern.document)


### PR DESCRIPTION
Adds support for setting the read concern at the collection level restoring compatibility with mongoengine 0.20.

Fixes: https://github.com/mongomock/mongomock/issues/625