### PR TITLE
added context mananger methods to mockmongo client

### DIFF
--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -61,6 +61,12 @@ class MongoClient(object):
     def __getattr__(self, attr):
         return self[attr]
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def __repr__(self):
         return "mongomock.MongoClient('{0}', {1})".format(self.host, self.port)
 

--- a/tests/test__client_api.py
+++ b/tests/test__client_api.py
@@ -123,3 +123,9 @@ class MongoClientApiTest(unittest.TestCase):
 
         client.one_db.my_collec.insert_one({})
         self.assertEqual(['one_db'], client.list_database_names())
+
+    def test_client_implements_context_managers(self):
+        with mongomock.MongoClient() as client:
+            client.one_db.my_collec.insert_one({})
+            result = client.one_db.my_collec.find_one({})
+            self.assertTrue(result)


### PR DESCRIPTION
The mockmongo client lacks the __enter__ and __exit__ methods that enables the use of 'with' syntax.
Simple pull request to add those methods.