### PR TITLE
doc_copy[key] = copy.deepcopy(val)

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -17,6 +17,7 @@ from six import moves, raise_from
 from mongomock import command_cursor
 from mongomock import filtering
 from mongomock import helpers
+from mongomock import OperationFailure
 from sentinels import NOTHING
 from six import moves
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -231,7 +231,7 @@ def _project_by_spec(doc, combined_projection_spec, is_include, container):
 
     if not is_include:
         for key, val in iteritems(doc):
-            doc_copy[key] = val
+            doc_copy[key] = copy.deepcopy(val)
 
     for key, spec in iteritems(combined_projection_spec):
         if key == '$':


### PR DESCRIPTION
Look in this case:
first_call = mongo_c.get_collection("collectionA").find_one({"search_field": "search_value"}, projection={"som_field":False})
second_call = mongo_c.get_collection("collectionA").find_one({"search_field": "search_value"}, projection={"som_field":False})

and there is an item with {"search_field": "search_value","som_field":"abc","some_field2":{"inner_field1":"original value"}}.

if we will do something like:
first_call ["some_field2"]["inner_field1"] = "new_value"
we will change the value of the second_call  too:
print(second_call ["some_field2"]["inner_field1"] )
>new_value
**which is wrong!!!**