### PR TITLE
Compatibility with version 3.11.0 of pymongo

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -352,18 +352,18 @@ class BulkOperationBuilder(object):
         self.insert(doc)
 
     def add_update(self, selector, doc, multi=False, upsert=False, collation=None,
-                   array_filters=None):
+                   array_filters=None, hint=None):
         if array_filters:
             raise NotImplementedError(
                 'Array filters are not implemented in mongomock yet.')
         write_operation = BulkWriteOperation(self, selector, is_upsert=upsert)
         write_operation.register_update_op(doc, multi)
 
-    def add_replace(self, selector, doc, upsert, collation=None):
+    def add_replace(self, selector, doc, upsert, collation=None, hint=None):
         write_operation = BulkWriteOperation(self, selector, is_upsert=upsert)
         write_operation.replace_one(doc)
 
-    def add_delete(self, selector, just_one, collation=None):
+    def add_delete(self, selector, just_one, collation=None, hint=None):
         write_operation = BulkWriteOperation(self, selector, is_upsert=False)
         write_operation.register_remove_op(not just_one)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4073,7 +4073,7 @@ class CollectionAPITest(TestCase):
                 {'_id': 1},
                 {'_id': 1}
             ])
-        self.assertEqual(str(cm.exception), 'batch op errors occurred')
+        self.assertTrue(str(cm.exception).startswith('batch op errors occurred'))
 
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test_insert_many_bulk_write_error_details(self):


### PR DESCRIPTION
The pymongo 3.11.0 introduced the `hint` parameter to the
`add_update()`, `add_replace()`, `add_delete()` methods

Fixes #648