### PR TITLE
TTL Indexes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ method in the following way:
    now_reference = mongomock.utcnow()
 
 This allows for a consistent way for users to mock the notion "now" in mongomock if they so choose. Please
-see `utcnow docstring for more details <mongomock/helpers.py#L52`_.
+see `utcnow docstring for more details <mongomock/helpers.py#L52>`_.
 
 Branching model
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,20 @@ NOTE: If the MongoDB image was updated, or you want to try a different MongoDB v
 you'll have to issue a `docker-compose down` before you do anything else to ensure you're running against
 the intended version.
 
+utcnow
+~~~~
+
+When developing features that need to make use of "now," please import and use the `helpers` module `utcnow`
+method in the following way:
+
+.. code-block:: python
+
+   import mongomock
+   # Awesome code!
+   now_reference = mongomock.utcnow()
+
+This allows for a consistent way for users to mock the notion "now" in mongomock if they so choose. Please
+see `utcnow docstring for more details <mongomock/helpers.py#L52`_.
 
 Branching model
 ~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -153,8 +153,8 @@ the intended version.
 utcnow
 ~~~~
 
-When developing features that need to make use of "now," please import and use the `helpers` module `utcnow`
-method in the following way:
+When developing features that need to make use of "now," please use the libraries :code:`utcnow` helper method
+in the following way:
 
 .. code-block:: python
 
@@ -162,7 +162,7 @@ method in the following way:
    # Awesome code!
    now_reference = mongomock.utcnow()
 
-This allows for a consistent way for users to mock the notion "now" in mongomock if they so choose. Please
+This provides users a consistent way to mock the notion of "now" in mongomock if they so choose. Please
 see `utcnow docstring for more details <mongomock/helpers.py#L52>`_.
 
 Branching model

--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -73,7 +73,7 @@ except ImportError:
     class InvalidURI(ConfigurationError):
         pass
 
-from .helpers import ObjectId  # noqa
+from .helpers import ObjectId, utcnow  # noqa
 from mongomock.__version__ import __version__
 
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1250,8 +1250,6 @@ class Collection(object):
         updater(doc, field_name, field_value)
 
     def _iter_documents(self, filter):
-        self._store.remove_expired_documents()
-
         # Validate the filter even if no documents can be returned.
         if self._store.is_empty:
             filter_applies(filter, {})

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1455,10 +1455,6 @@ class Collection(object):
     def create_index(self, key_or_list, cache_for=300, session=None, **kwargs):
         if session:
             raise_not_implemented('session', 'Mongomock does not handle sessions yet')
-        if 'expireAt' in kwargs:
-            raise_not_implemented(
-                'expireAt TTL index', 'Mongomock does not handle expireAt TTL index yet'
-            )
         index_list = helpers.create_index_list(key_or_list)
         is_unique = kwargs.pop('unique', False)
         is_sparse = kwargs.pop('sparse', False)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1452,6 +1452,8 @@ class Collection(object):
     def create_index(self, key_or_list, cache_for=300, session=None, **kwargs):
         if session:
             raise NotImplementedError('Mongomock does not handle sessions yet')
+        if 'expireAt' in kwargs:
+            raise NotImplementedError('Mongomock does not handle expireAt TTL index yet')
         index_list = helpers.create_index_list(key_or_list)
         is_unique = kwargs.pop('unique', False)
         is_sparse = kwargs.pop('sparse', False)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1462,7 +1462,7 @@ class Collection(object):
             index_dict['sparse'] = True
         if is_unique:
             index_dict['unique'] = True
-        if 'expireAfterSeconds' in kwargs:
+        if 'expireAfterSeconds' in kwargs and kwargs['expireAfterSeconds'] is not None:
             index_dict['expireAfterSeconds'] = kwargs.pop('expireAfterSeconds')
 
         existing_index = self._store.indexes.get(index_name)
@@ -1506,11 +1506,11 @@ class Collection(object):
                 raise TypeError(
                     '%s is not an instance of pymongo.operations.IndexModel' % index)
 
-        # TODO: expireAfterSeconds awareness(?)
         return [
             self.create_index(
                 index.document['key'].items(),
                 session=session,
+                expireAfterSeconds=index.document.get('expireAfterSeconds'),
                 unique=index.document.get('unique', False),
                 sparse=index.document.get('sparse', False),
                 name=index.document.get('name'))

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -6,7 +6,6 @@ try:
 except ImportError:
     from collections import Iterable, Mapping, MutableMapping
 import copy
-from datetime import datetime
 import functools
 import itertools
 import json
@@ -48,6 +47,7 @@ from six import string_types
 from six import text_type
 
 
+import mongomock
 from mongomock import aggregate
 from mongomock import ConfigurationError, DuplicateKeyError, BulkWriteError
 from mongomock.filtering import filter_applies
@@ -1500,7 +1500,7 @@ class Collection(object):
                         raise DuplicateKeyError('E11000 Duplicate Key Error', 11000)
                     indexed_list.append(index)
 
-        self._store.indexes[index_name] = index_dict
+        self._store.create_index(index_name, index_dict)
 
         return index_name
 
@@ -1529,7 +1529,7 @@ class Collection(object):
         else:
             name = index_or_name
         try:
-            del self._store.indexes[name]
+            self._store.drop_index(name)
         except KeyError:
             raise OperationFailure('index not found with name [%s]' % name)
 
@@ -2052,7 +2052,7 @@ def _current_date_updater(doc, field_name, value):
         if value == {'$type': 'timestamp'}:
             doc[field_name] = helpers.get_current_timestamp()
         else:
-            doc[field_name] = datetime.utcnow()
+            doc[field_name] = mongomock.utcnow()
 
 
 _updaters = {

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -2050,6 +2050,8 @@ def _pop_from_list(list_instance, mongo_pop_value):
 def _current_date_updater(doc, field_name, value):
     if isinstance(doc, dict):
         if value == {'$type': 'timestamp'}:
+            # TODO(juannyg): get_current_timestamp should also be using helpers utcnow,
+            # as it currently using time.time internally
             doc[field_name] = helpers.get_current_timestamp()
         else:
             doc[field_name] = mongomock.utcnow()

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -47,7 +47,7 @@ from six import string_types
 from six import text_type
 
 
-import mongomock
+import mongomock  # Used for utcnow - please see https://github.com/mongomock/mongomock#utcnow
 from mongomock import aggregate
 from mongomock import ConfigurationError, DuplicateKeyError, BulkWriteError
 from mongomock.filtering import filter_applies

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -49,6 +49,10 @@ ASCENDING = 1
 DESCENDING = -1
 
 
+def utcnow():
+    return datetime.utcnow()
+
+
 def print_deprecation_warning(old_param_name, new_param_name):
     warnings.warn(
         "'%s' has been deprecated to be in line with pymongo implementation, a new parameter '%s' "

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -50,6 +50,19 @@ DESCENDING = -1
 
 
 def utcnow():
+    """Simple wrapper for datetime.utcnow
+
+    This provides a centralized definition of "now" in the mongomock realm,
+    allowing users to transform the value of "now" to the future or the past,
+    based on their testing needs. For example:
+
+    ```python
+    def test_x(self):
+        with mock.patch("mongomock.utcnow") as mm_utc:
+            mm_utc = datetime.utcnow() + timedelta(hours=100)
+            # Test some things "100 hours" in the future
+    ```
+    """
     return datetime.utcnow()
 
 

--- a/mongomock/not_implemented.py
+++ b/mongomock/not_implemented.py
@@ -4,7 +4,6 @@
 _IGNORED_FEATURES = {
     'collation': False,
     'session': False,
-    'expireAt TTL index': False,
 }
 
 

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -1,9 +1,9 @@
 import collections
 import datetime
+import mongomock
 import six
+import six.moves
 import threading
-
-from six.moves import reduce
 
 lock = threading.RLock()
 
@@ -137,7 +137,7 @@ class CollectionStore(object):
     def _value_meets_expiry(self, val, expiry):
         val_to_compare = _get_dt_from_value(val)
         try:
-            return (datetime.datetime.utcnow() - val_to_compare).total_seconds() >= expiry
+            return (mongomock.utcnow() - val_to_compare).total_seconds() >= expiry
         except TypeError:
             return False
 
@@ -146,7 +146,7 @@ def _get_dt_from_value(val):
     if not val:
         return datetime.datetime.max
     if isinstance(val, list):
-        return reduce(_min_dt, [datetime.datetime.max] + val)
+        return six.moves.reduce(_min_dt, [datetime.datetime.max] + val)
     return val
 
 

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -1,6 +1,6 @@
 import collections
 import datetime
-import mongomock
+import mongomock  # Used for utcnow - please see https://github.com/mongomock/mongomock#utcnow
 import six
 import six.moves
 import threading

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -137,7 +137,7 @@ class CollectionStore(object):
     def _value_meets_expiry(self, val, expiry):
         val_to_compare = _get_dt_from_value(val)
         try:
-            return (datetime.datetime.now() - val_to_compare).total_seconds() >= expiry
+            return (datetime.datetime.utcnow() - val_to_compare).total_seconds() >= expiry
         except TypeError:
             return False
 

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -108,18 +108,18 @@ class CollectionStore(object):
 
     def remove_expired_documents(self):
         for index in six.itervalues(self.indexes):
-            # TODO: write test - compounds are ignored
-            #if len(index['key']) > 1:
-            #    continue
-
             # TODO: write test - check for expireAfterSeconds=0 boundary condition
             if index.get('expireAfterSeconds'):# is not None:
                 self._expire_documents(index)
 
     def _expire_documents(self, index):
-        # TODO: write test - pymongo/MongoDB accept but ignore non-integer expireAfterSeconds values
         print index
+        # TODO: write test - pymongo/MongoDB accept, but ignore non-integer expireAfterSeconds values
         expiry = int(index['expireAfterSeconds'])
+
+        # TODO: write test - compounds are ignored
+        #if len(index['key']) > 1:
+        #    continue
         indexed_field = index['key'][0][0]
         expired_ids = set()
 

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -119,7 +119,9 @@ class CollectionStore(object):
                 self._expire_documents(index)
 
     def _expire_documents(self, index):
-        # TODO: use a caching mechanism to avoid re-expiring the documents if we just did and no document was added / updated
+        # TODO(juannyg): use a caching mechanism to avoid re-expiring the documents if
+        # we just did and no document was added / updated
+
         # Ignore non-integer values
         try:
             expiry = int(index['expireAfterSeconds'])

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -114,7 +114,7 @@ class CollectionStore(object):
             self._documents[key] = val
 
     def __delitem__(self, key):
-        self._documents.pop(key)
+        del self._documents[key]
 
     def __len__(self):
         self._remove_expired_documents()

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -91,6 +91,8 @@ class CollectionStore(object):
             self._ttl_indexes[index_name] = index_dict
 
     def drop_index(self, index_name):
+        self._remove_expired_documents()
+
         # The main index object should raise a KeyError, but the
         # TTL indexes have no meaning to the outside.
         del self.indexes[index_name]

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1318,11 +1318,23 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_one({'value': datetime.now() - timedelta(seconds=5)})
         self.assertEqual(self.db.collection.find({}).count(), 0)
 
+    def test__ttl_expiration_of_0(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'value': datetime.now()})
+        self.assertEqual(self.db.collection.find({}).count(), 0)
+
+    def test__ttl_with_non_integer_value_is_ignored(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds='a')
+        self.db.collection.insert_one({'value': datetime.now()})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
+    def test__ttl_applied_to_compound_key_is_ignored(self):
+        self.db.collection.create_index([('field1', 1), ('field2', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'field1': datetime.now(), 'field2': 'val2'})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
     # def test__ttl_of_array_field_expiration
     # def test__ttl_of_array_field_without_datetime_does_not_expire
-    # def test__ttl_applied_to_compound_key_is_ignored
-    # def test__ttl_with_non_integer_value_is_ignored
-    # def test__ttl_expiration_of_0
     # def test__create_indexes_with_expireAfterSeconds
 
     def test__create_indexes_wrong_type(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1313,6 +1313,10 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.db.collection.create_index([('value', 1, 'foo', 'bar')])
 
+    def test__expireAt_ttl_index(self):
+        with self.assertRaises(NotImplementedError):
+            self.db.collection.create_index([('value', 1)], expireAt=datetime.now())
+
     def test__ttl_index_record_expiration(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
         self.db.collection.insert_one({'value': datetime.now() + timedelta(seconds=100)})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1315,31 +1315,31 @@ class CollectionAPITest(TestCase):
 
     def test__expireAt_ttl_index(self):
         with self.assertRaises(NotImplementedError):
-            self.db.collection.create_index([('value', 1)], expireAt=datetime.now())
+            self.db.collection.create_index([('value', 1)], expireAt=datetime.utcnow())
 
     def test__ttl_index_record_expiration(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
-        self.db.collection.insert_one({'value': datetime.now() + timedelta(seconds=100)})
+        self.db.collection.insert_one({'value': datetime.utcnow() + timedelta(seconds=100)})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
         self.db.collection.drop()
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
-        self.db.collection.insert_one({'value': datetime.now() - timedelta(seconds=5)})
+        self.db.collection.insert_one({'value': datetime.utcnow() - timedelta(seconds=5)})
         self.assertEqual(self.db.collection.find({}).count(), 0)
 
     def test__ttl_expiration_of_0(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
-        self.db.collection.insert_one({'value': datetime.now()})
+        self.db.collection.insert_one({'value': datetime.utcnow()})
         self.assertEqual(self.db.collection.find({}).count(), 0)
 
     def test__ttl_with_non_integer_value_is_ignored(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds='a')
-        self.db.collection.insert_one({'value': datetime.now()})
+        self.db.collection.insert_one({'value': datetime.utcnow()})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
     def test__ttl_applied_to_compound_key_is_ignored(self):
         self.db.collection.create_index([('field1', 1), ('field2', 1)], expireAfterSeconds=0)
-        self.db.collection.insert_one({'field1': datetime.now(), 'field2': 'val2'})
+        self.db.collection.insert_one({'field1': datetime.utcnow(), 'field2': 'val2'})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
     def test__ttl_of_array_field_expiration(self):
@@ -1348,7 +1348,7 @@ class CollectionAPITest(TestCase):
             'value': [
                 'a',
                 'b',
-                datetime.now() + timedelta(seconds=100)
+                datetime.utcnow() + timedelta(seconds=100)
             ]
         })
         self.assertEqual(self.db.collection.find({}).count(), 1)
@@ -1359,8 +1359,8 @@ class CollectionAPITest(TestCase):
             'value': [
                 'a',
                 'b',
-                datetime.now() - timedelta(seconds=5),
-                datetime.now() + timedelta(seconds=100)
+                datetime.utcnow() - timedelta(seconds=5),
+                datetime.utcnow() + timedelta(seconds=100)
             ]
         })
         self.assertEqual(self.db.collection.find({}).count(), 0)
@@ -1378,7 +1378,7 @@ class CollectionAPITest(TestCase):
         index_names = self.db.collection.create_indexes(indexes)
         self.assertEqual(1, len(index_names))
 
-        self.db.collection.insert_one({'value': datetime.now() - timedelta(seconds=5)})
+        self.db.collection.insert_one({'value': datetime.utcnow() - timedelta(seconds=5)})
         self.assertEqual(self.db.collection.find({}).count(), 0)
 
     def test__create_indexes_wrong_type(self):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1396,6 +1396,24 @@ class CollectionAPITest(TestCase):
             mongomock_utcnow.return_value = now + timedelta(100)
             self.assertEqual(self.db.collection.find({}).count(), 0)
 
+    def test__ttl_index_is_removed_if_collection_dropped(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'value': datetime.utcnow()})
+        self.assertEqual(self.db.collection.find({}).count(), 0)
+
+        self.db.collection.drop()
+        self.db.collection.insert_one({'value': datetime.utcnow()})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
+    def test__ttl_index_is_removed_when_index_is_dropped(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'value': datetime.utcnow()})
+        self.assertEqual(self.db.collection.find({}).count(), 0)
+
+        self.db.collection.drop_index('value_1')
+        self.db.collection.insert_one({'value': datetime.utcnow()})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__create_indexes_with_expireAfterSeconds(self):
         indexes = [

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1313,9 +1313,17 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.db.collection.create_index([('value', 1, 'foo', 'bar')])
 
-    def test__create_ttl_index(self):
-        with self.assertRaises(NotImplementedError):
-            self.db.collection.create_index([('value', 1)], expireAfterSeconds=3600)
+    def test__ttl_index_record_expiration(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
+        self.db.collection.insert_one({'value': datetime.now() - timedelta(seconds=5)})
+        self.assertEqual(self.db.collection.find({}).count(), 0)
+
+    # def test__ttl_of_array_field_expiration
+    # def test__ttl_of_array_field_without_datetime_does_not_expire
+    # def test__ttl_applied_to_compound_key_is_ignored
+    # def test__ttl_with_non_integer_value_is_ignored
+    # def test__ttl_expiration_of_0
+    # def test__create_indexes_with_expireAfterSeconds
 
     def test__create_indexes_wrong_type(self):
         indexes = [('value', 1), ('name', 1)]

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1323,10 +1323,6 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.db.collection.create_index([('value', 1, 'foo', 'bar')])
 
-    def test__expireAt_ttl_index(self):
-        with self.assertRaises(NotImplementedError):
-            self.db.collection.create_index([('value', 1)], expireAt=datetime.utcnow())
-
     def test__ttl_index_record_expiration(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
         self.db.collection.insert_one({'value': datetime.utcnow() + timedelta(seconds=100)})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1322,17 +1322,17 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.db.collection.create_index([('value', 1, 'foo', 'bar')])
 
-    def test__ttl_index_record_expiration(self):
-        self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
+    def test__ttl_index_ignores_record_in_the_future(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
         self.db.collection.insert_one({'value': datetime.utcnow() + timedelta(seconds=100)})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
-        self.db.collection.drop()
-        self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
+    def test__ttl_index_ignores_records_with_non_datetime_values(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
         self.db.collection.insert_one({'value': 'not a dt'})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
-        self.db.collection.drop()
+    def test__ttl_index_record_expiry(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
         self.db.collection.insert_one({'value': datetime.utcnow() - timedelta(seconds=5)})
         self.assertEqual(self.db.collection.find({}).count(), 0)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1414,6 +1414,13 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_one({'value': datetime.utcnow()})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
+    def test__ttl_index_removes_expired_documents_prior_to_removal(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'value': datetime.utcnow()})
+
+        self.db.collection.drop_index('value_1')
+        self.assertEqual(self.db.collection.find({}).count(), 0)
+
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__create_indexes_with_expireAfterSeconds(self):
         indexes = [

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1330,6 +1330,11 @@ class CollectionAPITest(TestCase):
 
         self.db.collection.drop()
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
+        self.db.collection.insert_one({'value': 'not a dt'})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
+        self.db.collection.drop()
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=5)
         self.db.collection.insert_one({'value': datetime.utcnow() - timedelta(seconds=5)})
         self.assertEqual(self.db.collection.find({}).count(), 0)
 
@@ -1346,6 +1351,11 @@ class CollectionAPITest(TestCase):
     def test__ttl_applied_to_compound_key_is_ignored(self):
         self.db.collection.create_index([('field1', 1), ('field2', 1)], expireAfterSeconds=0)
         self.db.collection.insert_one({'field1': datetime.utcnow(), 'field2': 'val2'})
+        self.assertEqual(self.db.collection.find({}).count(), 1)
+
+    def test__ttl_ignored_when_document_does_not_contain_indexed_field(self):
+        self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
+        self.db.collection.insert_one({'other_value': datetime.utcnow()})
         self.assertEqual(self.db.collection.find({}).count(), 1)
 
     def test__ttl_of_array_field_expiration(self):


### PR DESCRIPTION
Implement https://github.com/mongomock/mongomock/issues/655

Key points:

1. The first thing the `_iter_documents` method does now is remove expired documents. From what I could tell, this seemed to be the central point where any and all document examination occurred.
2. The TTL "time frame-of-reference" was made mock-able by using a centralized wrapper of `datetime.datetime.utcnow` - however further centralization can be handled separately. Given the stated desire, I wanted to try and plant this seed.

There are some other could improvements I can/would like to eventually add, specifically, some kind of `IndexWrapper` object to drastically improve the readability of the `_expire_documents` method, for example:

`idx.is_compound()` instead of `if len(index['key']) > 1`

but I wanted to get the core of the feature and where it might live in front of you first.

Feature and tests driven by: https://docs.mongodb.com/manual/core/index-ttl/