### PR TITLE
Implemented '$concatArrays' aggregation pipeline operator

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -31,7 +31,7 @@ If I miss to include a feature in the below list, Please feel free to add to the
   * Some string operators ($indexOfBytes, $trim, …)
   * Text search operator ($meta)
   * Projection operators ($map, $let)
-  * Array operators ($concatArrays, $isArray, $indexOfArray, …)
+  * Array operators ($isArray, $indexOfArray, …)
   * `$mergeObjects <https://docs.mongodb.com/manual/reference/operator/aggregation/mergeObjects/>`_
 * Operators within the query language (find):
   * `$expr <https://docs.mongodb.com/manual/reference/operator/query/expr/>`_

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -542,6 +542,10 @@ class _Parser(object):
             ' in Mongomock.' % operator)
 
     def _handle_array_operator(self, operator, value):
+        if operator == '$concatArrays':
+            parsed_list = list(self.parse_many(value))
+            return None if None in parsed_list else list(itertools.chain.from_iterable(parsed_list))
+
         if operator == '$size':
             if isinstance(value, list):
                 if len(value) != 1:

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -543,7 +543,16 @@ class _Parser(object):
 
     def _handle_array_operator(self, operator, value):
         if operator == '$concatArrays':
+            if not isinstance(value, (list, tuple)):
+                value = [value]
+
             parsed_list = list(self.parse_many(value))
+            for parsed_item in parsed_list:
+                if parsed_item is not None and not isinstance(parsed_item, (list, tuple)):
+                    raise OperationFailure(
+                        '$concatArrays only supports arrays, not {}'.format(type(parsed_item))
+                    )
+
             return None if None in parsed_list else list(itertools.chain.from_iterable(parsed_list))
 
         if operator == '$size':

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3062,6 +3062,26 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             }},
         ])
 
+    def test__aggregate_concatArrays(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            '_id': 1,
+            'a': [1, 2],
+            'b': ['foo', 'bar', 'baz'],
+            'c': {
+                'arr1': [123]
+            }
+        })
+        pipeline = [{
+            '$project': {
+                '_id': 0,
+                'concat': {'$concatArrays': ['$a', ['#', '*'], '$c.arr1', '$b']},
+                'concat_none': {'$concatArrays': ['$a', None, '$b']},
+                'concat_missing_field': {'$concatArrays': [[1, 2, 3], '$c.arr2']}
+            }
+        }]
+        self.cmp.compare.aggregate(pipeline)
+
     def test__aggregate_filter(self):
         self.cmp.do.drop()
         self.cmp.do.insert_many([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3095,29 +3095,17 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             }
         })
 
-        pipeline_parameter_not_array = [
-            {
-                '$project': {
-                    'concat_parameter_not_array': {'$concatArrays': 42}
-                }
+        self.cmp.compare_exceptions.aggregate([{
+            '$project': {
+                'concat_parameter_not_array': {'$concatArrays': 42}
             }
-        ]
-        with self.assertRaises(OperationFailure):
-            self.mongo_collection.aggregate(pipeline_parameter_not_array)
-        with self.assertRaises(OperationFailure):
-            self.fake_collection.aggregate(pipeline_parameter_not_array)
+        }])
 
-        pipeline_item_not_array = [
-            {
-                '$project': {
-                    'concat_item_not_array': {'$concatArrays': [[1, 2], '$a']}
-                }
+        self.cmp.compare_exceptions.aggregate([{
+            '$project': {
+                'concat_item_not_array': {'$concatArrays': [[1, 2], '$a']}
             }
-        ]
-        with self.assertRaises(OperationFailure):
-            self.mongo_collection.aggregate(pipeline_item_not_array)
-        with self.assertRaises(OperationFailure):
-            self.fake_collection.aggregate(pipeline_item_not_array)
+        }])
 
     def test__aggregate_filter(self):
         self.cmp.do.drop()


### PR DESCRIPTION
This PR implements the [`$concatArrays`](https://docs.mongodb.com/manual/reference/operator/aggregation/concatArrays/) aggregation pipeline operator.