### PR TITLE
performance improvement: create only one instance of _Filterer

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -45,7 +45,7 @@ def filter_applies(search_filter, document):
     This function implements MongoDB's matching strategy over documents in the find() method
     and other related scenarios (like $elemMatch)
     """
-    return _Filterer().apply(search_filter, document)
+    return _filterer_inst.apply(search_filter, document)
 
 
 class _Filterer(object):
@@ -516,3 +516,6 @@ class BsonComparable(object):
 
     def __lt__(self, other):
         return bson_compare(operator.lt, self.obj, other.obj)
+
+
+_filterer_inst = _Filterer()


### PR DESCRIPTION
`_Filterer` is stateless, so no need to initialize it on every call to `filter_applies`. It cuts the filtering time by ±30%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongomock/mongomock/674)
<!-- Reviewable:end -->
