### PR TITLE
Sublist candidate handling update

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -242,10 +242,14 @@ def _iter_key_candidates_sublist(key, doc):
 
     if sub_key_int is None:
         # subkey is not an integer...
-        return [x
-                for sub_doc in doc
-                if isinstance(sub_doc, dict) and sub_key in sub_doc
-                for x in iter_key_candidates(key_remainder, sub_doc[sub_key])]
+        ret = []
+        for sub_doc in doc:
+            if isinstance(sub_doc, dict):
+                if sub_key in sub_doc:
+                    ret.extend(iter_key_candidates(key_remainder, sub_doc[sub_key]))
+                else:
+                    ret.append(NOTHING)
+        return ret
 
     # subkey is an index
     if sub_key_int >= len(doc):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4811,6 +4811,13 @@ class CollectionAPITest(TestCase):
         results = self.db.collection.find({'shape.color': {'$eq': 'red'}})
         self.assertEqual([1, 3, 6], [doc['_id'] for doc in results])
 
+        # testing eq operation with null as value
+        results = self.db.collection.find({'shape.color': {'$eq': None}})
+        self.assertEqual([4, 5], [doc['_id'] for doc in results])
+
+        results = self.db.collection.find({'shape.color': None})
+        self.assertEqual([4, 5], [doc['_id'] for doc in results])
+
     def test__filter_ne_on_array(self):
         """$ne and $nin on array only matches if no element of the array matches."""
         collection = self.db.collection

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -719,6 +719,19 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find(
             {'field.0.a': {'$exists': True}, 'field.1.a': {'$exists': False}})
 
+    def test__find_in_array_equal_null(self):
+        self.cmp.do.insert_many([
+            {'_id': 1, 'shape': [{'color': 'red'}]},
+            {'_id': 2, 'shape': [{'color': 'yellow'}]},
+            {'_id': 3, 'shape': [{'color': 'red'}, {'color': 'yellow'}]},
+            {'_id': 4, 'shape': [{'size': 3}]},
+            {'_id': 5},
+            {'_id': 6, 'shape': {'color': ['red', 'yellow']}},
+        ])
+
+        self.cmp.compare_ignore_order.find({'shape.color': {'$eq': None}})
+        self.cmp.compare_ignore_order.find({'shape.color': None})
+
     def test__find_notequal(self):
         """Test searching with operators other than equality."""
         bob = {'_id': 1, 'name': 'bob'}

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -727,6 +727,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             {'_id': 4, 'shape': [{'size': 3}]},
             {'_id': 5},
             {'_id': 6, 'shape': {'color': ['red', 'yellow']}},
+            {'_id': 7, 'shape': [{'color': 'red'}, {'color': None}]},
         ])
 
         self.cmp.compare_ignore_order.find({'shape.color': {'$eq': None}})


### PR DESCRIPTION
Fix #673 

In case of array values, `NOTHING` object seemed rather ignored.

[here](https://github.com/studentofkyoto/mongomock/tree/find-on-array) is more boilerplate version just in case.

I am new to open source contribution. Please guide me through if I am doing something wrong.
