### PR TITLE
List  collection names with filter

### DIFF
--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -68,7 +68,7 @@ class Database(object):
         return self.list_collection_names(session=session)
 
     def _verify_list_collection_supported_op(self, keys):
-        if keys - list_collection_filter_allowed_operators:
+        if set(keys) - list_collection_filter_allowed_operators:
             raise NotImplementedError(
                 'list collection names filter operator {0} is not implemented yet in mongomock '
                 'allowed operators are {1}'.format(keys, list_collection_filter_allowed_operators))

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -18,7 +18,14 @@ try:
 except ImportError:
     _READ_PREFERENCE_PRIMARY = read_preferences.PRIMARY
 
-list_collection_filter_allowed_operators = frozenset(['$regex', '$eq', '$ne'])
+_LIST_COLLECTION_FILTER_ALLOWED_OPERATORS = frozenset(['$regex', '$eq', '$ne'])
+
+
+def _verify_list_collection_supported_op(keys):
+    if set(keys) - _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS:
+        raise NotImplementedError(
+            'list collection names filter operator {0} is not implemented yet in mongomock '
+            'allowed operators are {1}'.format(keys, _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS))
 
 
 class Database(object):
@@ -67,17 +74,11 @@ class Database(object):
 
         return self.list_collection_names(session=session)
 
-    def _verify_list_collection_supported_op(self, keys):
-        if set(keys) - list_collection_filter_allowed_operators:
-            raise NotImplementedError(
-                'list collection names filter operator {0} is not implemented yet in mongomock '
-                'allowed operators are {1}'.format(keys, list_collection_filter_allowed_operators))
-
     def list_collection_names(self, filter=None, session=None):
         """filter: only name field type with eq,ne or regex operator
 
         session: not supported
-        supported operator are $eq, $ne, $regex
+        for supported operator please see _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS
         """
         field_name = 'name'
 
@@ -86,8 +87,8 @@ class Database(object):
 
         if filter:
             if not filter.get('name'):
-                raise NotImplementedError(' list collection {0} might be valid but is not '
-                                          ' implemented yet in mongomock'.format(filter))
+                raise NotImplementedError('list collection {0} might be valid but is not '
+                                          'implemented yet in mongomock'.format(filter))
 
             filter = {field_name: {'$eq': filter.get(field_name)}} \
                 if isinstance(filter.get(field_name), str) else filter

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -66,10 +66,10 @@ class Database(object):
         return self.list_collection_names(session=session)
 
     def list_collection_names(self, filter=None, session=None):
-        """
-            filter: only name field type with eq,ne or regex operator
-            session: not supported
-            supported operator are $eq, $ne, $regex
+        """filter: only name field type with eq,ne or regex operator
+
+        session: not supported
+        supported operator are $eq, $ne, $regex
         """
 
         allowed_operators = ['$regex', '$eq', '$ne']
@@ -79,7 +79,8 @@ class Database(object):
             for key in keys:
                 if key not in allowed_operators:
                     raise NotImplementedError(
-                        'Mongomock list collection names filter operators are {0}'.format(allowed_operators))
+                        'Mongomock list collection names filter'
+                        ' operators are {0}'.format(allowed_operators))
 
         if session:
             raise NotImplementedError('Mongomock does not handle sessions yet')
@@ -88,12 +89,14 @@ class Database(object):
             if not filter.get('name'):
                 raise NotImplementedError('Mongomock list collection names support name type only')
 
-            filter = {filed_name: {'$eq': filter.get(filed_name)}} if isinstance(filter.get(filed_name), str) else filter
+            filter = {filed_name: {'$eq': filter.get(filed_name)}} \
+                if isinstance(filter.get(filed_name), str) else filter
 
             verify_supported_op(filter.get(filed_name).keys())
 
             return [name for name in list(self._store._collections)
-                    if filter_applies(filter, {filed_name: name}) and not name.startswith('system.')]
+                    if filter_applies(filter, {filed_name: name}) and
+                    not name.startswith('system.')]
 
         return [
             name for name in self._get_created_collections()

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -98,7 +98,7 @@ class Database(object):
             filter = {field_name: {'$eq': filter.get(field_name)}} \
                 if isinstance(filter.get(field_name), str) else filter
 
-            self._verify_list_collection_supported_op(filter.get(field_name).keys())
+            _verify_list_collection_supported_op(filter.get(field_name).keys())
 
             return [name for name in list(self._store._collections)
                     if filter_applies(filter, {field_name: name}) and

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     _READ_PREFERENCE_PRIMARY = read_preferences.PRIMARY
 
+list_collection_filter_allowed_operators = frozenset(['$regex', '$eq', '$ne'])
+
 
 class Database(object):
 
@@ -65,37 +67,35 @@ class Database(object):
 
         return self.list_collection_names(session=session)
 
+    def _verify_list_collection_supported_op(self, keys):
+        if keys - list_collection_filter_allowed_operators:
+            raise NotImplementedError(
+                'list collection names filter operator {0} is not implemented yet in mongomock '
+                'allowed operators are {1}'.format(keys, list_collection_filter_allowed_operators))
+
     def list_collection_names(self, filter=None, session=None):
         """filter: only name field type with eq,ne or regex operator
 
         session: not supported
         supported operator are $eq, $ne, $regex
         """
-
-        allowed_operators = ['$regex', '$eq', '$ne']
-        filed_name = 'name'
-
-        def verify_supported_op(keys):
-            for key in keys:
-                if key not in allowed_operators:
-                    raise NotImplementedError(
-                        'Mongomock list collection names filter'
-                        ' operators are {0}'.format(allowed_operators))
+        field_name = 'name'
 
         if session:
             raise NotImplementedError('Mongomock does not handle sessions yet')
 
         if filter:
             if not filter.get('name'):
-                raise NotImplementedError('Mongomock list collection names support name type only')
+                raise NotImplementedError(' list collection {0} might be valid but is not '
+                                          ' implemented yet in mongomock'.format(filter))
 
-            filter = {filed_name: {'$eq': filter.get(filed_name)}} \
-                if isinstance(filter.get(filed_name), str) else filter
+            filter = {field_name: {'$eq': filter.get(field_name)}} \
+                if isinstance(filter.get(field_name), str) else filter
 
-            verify_supported_op(filter.get(filed_name).keys())
+            self._verify_list_collection_supported_op(filter.get(field_name).keys())
 
             return [name for name in list(self._store._collections)
-                    if filter_applies(filter, {filed_name: name}) and
+                    if filter_applies(filter, {field_name: name}) and
                     not name.startswith('system.')]
 
         return [

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -1,6 +1,8 @@
 import re
 import warnings
 
+from mongomock.filtering import filter_applies, _regex
+
 from . import CollectionInvalid
 from . import InvalidName
 from . import OperationFailure
@@ -66,25 +68,40 @@ class Database(object):
 
     def list_collection_names(self, filter: dict = None, session=None):
         """
-            filter:  only name field type equal and regex operator
+            filter:  only name field type with equal or regex operator
             session: not supported
+            motice that the filter syntax is diffrent then collection syntax
         """
         if session:
             raise NotImplementedError('Mongomock does not handle sessions yet')
 
-        if filter and filter.get('name'):
-            regex = filter.get('name').get('$regex') if isinstance(filter.get('name'), dict) and filter.get('name').get('$regex') else None
-            if regex:
+
+
+        if filter:
+            if not filter.get('name'):
+                raise NotImplementedError('Mongomock list collection names support name type only')
+            cols_names = self._get_created_collections()
+            regex = filter.get('name').get('$regex') if isinstance(filter.get('name'), dict) else filter.get('name')
+            if _regex(cols_names, regex):
+
                 return [
-                    name for name in self._get_created_collections()
+                    name for name in cols_names
                     if re.match(regex, name) and not name.startswith('system.')
                 ]
-            elif filter.get('name'):
-                name_filter = filter.get('name')
-                return [
-                    name for name in self._get_created_collections()
-                    if not name.startswith('system.') and name == name_filter
-                ]
+
+
+            # regex = filter.get('name').get('$regex') if isinstance(filter.get('name'), dict) and filter.get('name').get('$regex') else None
+            # if regex:
+            #     return [
+            #         name for name in self._get_created_collections()
+            #         if re.match(regex, name) and not name.startswith('system.')
+            #     ]
+            # elif filter.get('name'):
+            #     name_filter = filter.get('name')
+            #     return [
+            #         name for name in self._get_created_collections()
+            #         if not name.startswith('system.') and name == name_filter
+            #     ]
             else:
                 raise NotImplementedError('Mongomock list collection filter only support name'
                                           ' field type equal and regex expression')

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -79,7 +79,7 @@ class Database(object):
             for key in keys:
                 if key not in allowed_operators:
                     raise NotImplementedError(
-                        f'Mongomock list collection names filter operators are {allowed_operators}')
+                        'Mongomock list collection names filter operators are {0}'.format(allowed_operators))
 
         if session:
             raise NotImplementedError('Mongomock does not handle sessions yet')
@@ -95,8 +95,6 @@ class Database(object):
             return [name for name in list(self._store._collections)
                     if filter_applies(filter, {filed_name: name}) and not name.startswith('system.')]
 
-            raise NotImplementedError('Mongomock list collection filter only support name'
-                                      ' field type equal and regex expression')
         return [
             name for name in self._get_created_collections()
             if not name.startswith('system.')

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -65,7 +65,7 @@ class Database(object):
 
         return self.list_collection_names(session=session)
 
-    def list_collection_names(self, filter: dict = None, session=None):
+    def list_collection_names(self, filter=None, session=None):
         """
             filter: only name field type with eq,ne or regex operator
             session: not supported

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5988,7 +5988,7 @@ class CollectionAPITest(TestCase):
         for day in range(10):
             new_date = datetime.now() - timedelta(day)
             self.db.create_collection(f'historical_{new_date.strftime("%Y_%m_%d")}')
-        assert len(self.db.list_collection_names()) == 10
+        # assert len(self.db.list_collection_names()) == 10
 
         assert len(self.db.list_collection_names(
             filter={

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6006,3 +6006,11 @@ class CollectionAPITest(TestCase):
 
         # test equal
         assert col_name in self.db.list_collection_names(filter={'name': col_name})
+
+        # neg invalid field
+        with self.assertRaises(NotImplementedError):
+            self.db.list_collection_names(filter={'_id': {'$ne': col_name}})
+
+        # neg invalid operator
+        with self.assertRaises(NotImplementedError):
+            self.db.list_collection_names(filter={'name': {'$ge': col_name}})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5983,3 +5983,19 @@ class CollectionAPITest(TestCase):
         ids = set(doc['_id'] for doc in self.db.collection.find(
             {'arr': {'$elemMatch': {'$lt': 10, '$gt': 4}}}, {'_id': 1}))
         self.assertEqual({1, 2}, ids)
+
+    def test_list_collection_filter(self):
+        for day in range(10):
+            new_date = datetime.now() - timedelta(day)
+            self.db.create_collection(f'historical_{new_date.strftime("%Y_%m_%d")}')
+        assert len(self.db.list_collection_names()) == 10
+
+        assert len(self.db.list_collection_names(
+            filter={
+                'name': {'$regex': fr'historical_\d{{4}}_\d{{2}}_\d{{2}}'}
+            }
+        )) == 10
+        new_date = datetime.now() - timedelta(1)
+        assert self.db.list_collection_names(filter={
+            'name': f'historical_{new_date.strftime("%Y_%m_%d")}'
+        })

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5984,18 +5984,25 @@ class CollectionAPITest(TestCase):
             {'arr': {'$elemMatch': {'$lt': 10, '$gt': 4}}}, {'_id': 1}))
         self.assertEqual({1, 2}, ids)
 
-    def test_list_collection_filter(self):
+    def test_list_collection_names_filter(self):
+        self.db.create_collection('aggregator')
         for day in range(10):
             new_date = datetime.now() - timedelta(day)
             self.db.create_collection(f'historical_{new_date.strftime("%Y_%m_%d")}')
-        # assert len(self.db.list_collection_names()) == 10
 
+        # test without filter
+        assert len(self.db.list_collection_names()) == 11
+
+        # test regex
         assert len(self.db.list_collection_names(
-            filter={
-                'name': {'$regex': fr'historical_\d{{4}}_\d{{2}}_\d{{2}}'}
-            }
+            filter={'name': {'$regex': fr'historical_\d{{4}}_\d{{2}}_\d{{2}}'}}
         )) == 10
+
         new_date = datetime.now() - timedelta(1)
-        assert self.db.list_collection_names(filter={
-            'name': f'historical_{new_date.strftime("%Y_%m_%d")}'
-        })
+        col_name = f'historical_{new_date.strftime("%Y_%m_%d")}'
+
+        # test not equal
+        assert len(self.db.list_collection_names( filter={'name': {'$ne': col_name}})) == 10
+
+        # test equal
+        assert col_name in self.db.list_collection_names(filter={'name': col_name})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5988,18 +5988,18 @@ class CollectionAPITest(TestCase):
         self.db.create_collection('aggregator')
         for day in range(10):
             new_date = datetime.now() - timedelta(day)
-            self.db.create_collection(f'historical_{new_date.strftime("%Y_%m_%d")}')
+            self.db.create_collection('historical_{0}'.format(new_date.strftime("%Y_%m_%d")))
 
         # test without filter
         assert len(self.db.list_collection_names()) == 11
 
         # test regex
         assert len(self.db.list_collection_names(
-            filter={'name': {'$regex': r'historical_\d{{4}}_\d{{2}}_\d{{2}}'}}
+            filter={'name': {'$regex': r'historical_\d{4}_\d{2}_\d{2}'}}
         )) == 10
 
         new_date = datetime.now() - timedelta(1)
-        col_name = f'historical_{new_date.strftime("%Y_%m_%d")}'
+        col_name = 'historical_{0}'.format(new_date.strftime("%Y_%m_%d"))
 
         # test not equal
         assert len(self.db.list_collection_names( filter={'name': {'$ne': col_name}})) == 10

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5996,7 +5996,7 @@ class CollectionAPITest(TestCase):
 
         # test regex
         assert len(self.db.list_collection_names(filter={
-            'name': {'$rewgex': r'historical_\d{4}_\d{2}_\d{2}'}
+            'name': {'$regex': r'historical_\d{4}_\d{2}_\d{2}'}
         })) == 10
 
         new_date = datetime.now() - timedelta(1)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5985,24 +5985,25 @@ class CollectionAPITest(TestCase):
         self.assertEqual({1, 2}, ids)
 
     def test_list_collection_names_filter(self):
+        now = datetime.now()
         self.db.create_collection('aggregator')
         for day in range(10):
-            new_date = datetime.now() - timedelta(day)
+            new_date = now - timedelta(day)
             self.db.create_collection('historical_{0}'.format(new_date.strftime('%Y_%m_%d')))
 
         # test without filter
-        assert len(self.db.list_collection_names()) == 11
+        self.assertEqual(len(self.db.list_collection_names()), 11)
 
         # test regex
         assert len(self.db.list_collection_names(filter={
-            'name': {'$regex': r'historical_\d{4}_\d{2}_\d{2}'}
+            'name': {'$rewgex': r'historical_\d{4}_\d{2}_\d{2}'}
         })) == 10
 
         new_date = datetime.now() - timedelta(1)
         col_name = 'historical_{0}'.format(new_date.strftime('%Y_%m_%d'))
 
         # test not equal
-        assert len(self.db.list_collection_names(filter={'name': {'$ne': col_name}})) == 10
+        self.assertEqual(len(self.db.list_collection_names(filter={'name': {'$ne': col_name}})), 10)
 
         # test equal
         assert col_name in self.db.list_collection_names(filter={'name': col_name})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5995,7 +5995,7 @@ class CollectionAPITest(TestCase):
 
         # test regex
         assert len(self.db.list_collection_names(
-            filter={'name': {'$regex': fr'historical_\d{{4}}_\d{{2}}_\d{{2}}'}}
+            filter={'name': {'$regex': r'historical_\d{{4}}_\d{{2}}_\d{{2}}'}}
         )) == 10
 
         new_date = datetime.now() - timedelta(1)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5988,7 +5988,7 @@ class CollectionAPITest(TestCase):
         self.db.create_collection('aggregator')
         for day in range(10):
             new_date = datetime.now() - timedelta(day)
-            self.db.create_collection('historical_{0}'.format(new_date.strftime("%Y_%m_%d")))
+            self.db.create_collection('historical_{0}'.format(new_date.strftime('%Y_%m_%d')))
 
         # test without filter
         assert len(self.db.list_collection_names()) == 11
@@ -5999,7 +5999,7 @@ class CollectionAPITest(TestCase):
         })) == 10
 
         new_date = datetime.now() - timedelta(1)
-        col_name = 'historical_{0}'.format(new_date.strftime("%Y_%m_%d"))
+        col_name = 'historical_{0}'.format(new_date.strftime('%Y_%m_%d'))
 
         # test not equal
         assert len(self.db.list_collection_names( filter={'name': {'$ne': col_name}})) == 10

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6002,7 +6002,7 @@ class CollectionAPITest(TestCase):
         col_name = 'historical_{0}'.format(new_date.strftime('%Y_%m_%d'))
 
         # test not equal
-        assert len(self.db.list_collection_names( filter={'name': {'$ne': col_name}})) == 10
+        assert len(self.db.list_collection_names(filter={'name': {'$ne': col_name}})) == 10
 
         # test equal
         assert col_name in self.db.list_collection_names(filter={'name': col_name})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5994,9 +5994,9 @@ class CollectionAPITest(TestCase):
         assert len(self.db.list_collection_names()) == 11
 
         # test regex
-        assert len(self.db.list_collection_names(
-            filter={'name': {'$regex': r'historical_\d{4}_\d{2}_\d{2}'}}
-        )) == 10
+        assert len(self.db.list_collection_names(filter={
+            'name': {'$regex': r'historical_\d{4}_\d{2}_\d{2}'}
+        })) == 10
 
         new_date = datetime.now() - timedelta(1)
         col_name = 'historical_{0}'.format(new_date.strftime("%Y_%m_%d"))


### PR DESCRIPTION
add filter support for list collection names 
https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.list_collection_names

i was missing the regex support :-)
also equal and none equal are supported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongomock/mongomock/681)
<!-- Reviewable:end -->
