### PR TITLE
Fix find data with projection is not immutable

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -234,7 +234,7 @@ def _project_by_spec(doc, combined_projection_spec, is_include, container):
 
     if not is_include:
         for key, val in iteritems(doc):
-            doc_copy[key] = val
+            doc_copy[key] = copy.deepcopy(val)
 
     for key, spec in iteritems(combined_projection_spec):
         if key == '$':
@@ -253,7 +253,7 @@ def _project_by_spec(doc, combined_projection_spec, is_include, container):
                 doc_copy[key] = _project_by_spec(sub, spec, is_include, container)
         else:
             if is_include:
-                doc_copy[key] = doc[key]
+                doc_copy[key] = copy.deepcopy(doc[key])
             else:
                 doc_copy.pop(key, None)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6468,3 +6468,31 @@ class CollectionAPITest(TestCase):
     def test__hashable(self):
         with self.assertRaises(TypeError):
             {self.db.a, self.db.b}  # pylint: disable=pointless-statement
+
+    def test__find_one_immutable_data_projection(self):
+        # find_one data should be immutable when using projection
+        collection = self.db.collection
+        collection.insert_one({'_id': 1, 'years': {'last_job': 2010}})
+
+        item = collection.find_one({'_id': 1}, projection={'years': True})
+        item['years']['last_job'] = 2021
+
+        item_2 = collection.find_one({'_id': 1})
+        self.assertEqual(item_2['years']['last_job'], 2010)
+
+    def test__find_many_immutable_data_projection(self):
+        # find data should be immutable when using projection
+        collection = self.db.collection
+        collection.insert_one({'_id': 1, 'a': 'it', 'years': {'it': {'last_job': 2011}}})
+        collection.insert_one({'_id': 2, 'a': 'it', 'years': {'it': {'last_job': 2012}}})
+
+        items = collection.find({'a': 'it'}, projection={'years': True})
+        for item in items:
+            item['years']['it']['last_job'] = 2021
+
+        items_2 = list(collection.find({'a': 'it'}, projection={'years': True}))
+
+        self.assertEqual(items_2, [
+            {'_id': 1, 'years': {'it': {'last_job': 2011}}},
+            {'_id': 2, 'years': {'it': {'last_job': 2012}}},
+        ])


### PR DESCRIPTION
When finding document with projection, currently data returned is mutable. It should be immutable.

How to reproduce:

```
# Prepare data
collection.insert_one({'_id': 1, 'years': {'last_job': 2010}})
item_before = collection.find_one({'_id': 1}, projection={'years': True})
# Try to update document dict, bug is here
item_before['years']['last_job'] = 2021

# Get item again
item_after = collection.find_one({'_id': 1})

# data should be 2010, but currently it is 2021
assert item_before['years']['last_job'] == 2010

```

Similar issue to old PR https://github.com/mongomock/mongomock/pull/643
