### PR TITLE
Index is parsed during $arrayElemAt. Fix #607

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -366,6 +366,7 @@ class _Parser(object):
         if operator == '$arrayElemAt':
             key, index = values
             array = self._parse_basic_expression(key)
+            index = self.parse(index)
             return array[index]
         raise NotImplementedError("Although '%s' is a valid project operator for the "
                                   'aggregation pipeline, it is currently not implemented '

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3077,6 +3077,24 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             }},
         ])
 
+    def test_aggregate_bug_607(self):
+        """Regression test for bug https://github.com/mongomock/mongomock/issues/607."""
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            'index': 2,
+            'values': [0,1,5]
+        })
+        self.cmp.compare.aggregate([
+            {'$project': {
+                "values_index":{'$arrayElemAt': ["$values","$index"]}
+            }}
+        ])
+        self.cmp.compare.aggregate([
+            {'$project': {
+                "values_index":{'$arrayElemAt': ["$values",{"$add":[1,1]}]}
+            }}
+        ])
+
     def test__aggregate_cond_mongodb_to_bool(self):
         """Regression test for bug https://github.com/mongomock/mongomock/issues/650"""
         self.cmp.compare_ignore_order.aggregate([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3082,16 +3082,16 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         self.cmp.do.drop()
         self.cmp.do.insert_one({
             'index': 2,
-            'values': [0,1,5]
+            'values': [0, 1, 5]
         })
         self.cmp.compare.aggregate([
             {'$project': {
-                "values_index":{'$arrayElemAt': ["$values","$index"]}
+                'values_index': {'$arrayElemAt': ['$values', '$index']}
             }}
         ])
         self.cmp.compare.aggregate([
             {'$project': {
-                "values_index":{'$arrayElemAt': ["$values",{"$add":[1,1]}]}
+                'values_index': {'$arrayElemAt': ['$values', {'$add': [1, 1]}]}
             }}
         ])
 


### PR DESCRIPTION
Proposition for fixing #607

Index part  in $arrayElemAt was only working with integer. 
Now work with an other value of the document; or a function

I was not able to run the mongomock units test locally; but i try my modification on in my own project, so the test I added was not test locally