### PR TITLE
Basic support for document validation on inserts and updates.

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -460,8 +460,9 @@ class Collection(object):
     def insert_one(self, document, bypass_document_validation=False, session=None):
         if not bypass_document_validation:
             validate_is_mutable_mapping('document', document)
-        return InsertOneResult(self._insert(document, session,
-            validate=not bypass_document_validation), acknowledged=True)
+        return InsertOneResult(
+            self._insert(document, session, validate=not bypass_document_validation),
+            acknowledged=True)
 
     def insert_many(self, documents, ordered=True, bypass_document_validation=False, session=None):
         if not isinstance(documents, Iterable) or not documents:
@@ -471,8 +472,8 @@ class Collection(object):
             for document in documents:
                 validate_is_mutable_mapping('document', document)
         return InsertManyResult(
-            self._insert(documents, session, ordered=ordered, validate=not
-                bypass_document_validation),
+            self._insert(documents, session, ordered=ordered,
+                         validate=not bypass_document_validation),
             acknowledged=True)
 
     @property
@@ -916,13 +917,14 @@ class Collection(object):
                             # new document
                             validate = False
 
-                    if validate:
-                        try:
-                            validate_against_validator(existing_document, options)
-                        except WriteError:
-                            # Rollback.
-                            self._store[original_document_snapshot['_id']] = original_document_snapshot
-                            raise
+                # Check again if validation is still required
+                if validate:
+                    try:
+                        validate_against_validator(existing_document, options)
+                    except WriteError:
+                        # Rollback.
+                        self._store[original_document_snapshot['_id']] = original_document_snapshot
+                        raise
 
                 # Make sure it still respect the unique indexes and, if not, to
                 # revert modifications

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -121,6 +121,22 @@ def validate_write_concern_params(**params):
         WriteConcern(**params)
 
 
+def validate_against_validator(document, options):
+    validator = options.get('validator')
+    validation_level = options.get('validationLevel', 'strict')
+    validation_action = options.get('validationAction', 'error')
+
+    if (not validator or validation_level == 'off' or
+            validation_action == 'warn'):
+        # Don't bother performing validation; in the case of
+        # validation_action == 'warn' it only logs a warning in the real
+        # database
+        return
+
+    if not filter_applies(validator, document):
+        raise WriteError('Document failed validation', code=121)
+
+
 class BulkWriteOperation(object):
     def __init__(self, builder, selector, is_upsert=False):
         self.builder = builder
@@ -444,7 +460,8 @@ class Collection(object):
     def insert_one(self, document, bypass_document_validation=False, session=None):
         if not bypass_document_validation:
             validate_is_mutable_mapping('document', document)
-        return InsertOneResult(self._insert(document, session), acknowledged=True)
+        return InsertOneResult(self._insert(document, session,
+            validate=not bypass_document_validation), acknowledged=True)
 
     def insert_many(self, documents, ordered=True, bypass_document_validation=False, session=None):
         if not isinstance(documents, Iterable) or not documents:
@@ -454,14 +471,15 @@ class Collection(object):
             for document in documents:
                 validate_is_mutable_mapping('document', document)
         return InsertManyResult(
-            self._insert(documents, session, ordered=ordered),
+            self._insert(documents, session, ordered=ordered, validate=not
+                bypass_document_validation),
             acknowledged=True)
 
     @property
     def _store(self):
         return self._db_store[self._name]
 
-    def _insert(self, data, session=None, ordered=True):
+    def _insert(self, data, session=None, ordered=True, validate=True):
         if session:
             raise_not_implemented('session', 'Mongomock does not handle sessions yet')
         if not isinstance(data, Mapping):
@@ -470,7 +488,7 @@ class Collection(object):
             num_inserted = 0
             for index, item in enumerate(data):
                 try:
-                    results.append(self._insert(item))
+                    results.append(self._insert(item, validate=validate))
                 except WriteError as error:
                     write_errors.append({
                         'index': index,
@@ -496,6 +514,9 @@ class Collection(object):
         if BSON:
             # bson validation
             BSON.encode(data, check_keys=True)
+
+        if validate:
+            validate_against_validator(data, self.options())
 
         # Like pymongo, we should fill the _id in the inserted dict (odd behavior,
         # but we need to stick to it), so we must patch in-place the data dict
@@ -550,6 +571,9 @@ class Collection(object):
             sub_doc = sub_doc[part]
         return True
 
+    def options(self):
+        return copy.deepcopy(self._store.options)
+
     def update_one(
             self, filter, update, upsert=False, bypass_document_validation=False, hint=None,
             session=None, collation=None):
@@ -557,7 +581,8 @@ class Collection(object):
             validate_ok_for_update(update)
         return UpdateResult(
             self._update(
-                filter, update, upsert=upsert, hint=hint, session=session, collation=collation),
+                filter, update, upsert=upsert, hint=hint, session=session,
+                collation=collation, validate=not bypass_document_validation),
             acknowledged=True)
 
     def update_many(
@@ -568,7 +593,7 @@ class Collection(object):
         return UpdateResult(
             self._update(
                 filter, update, upsert=upsert, multi=True, hint=hint, session=session,
-                collation=collation),
+                collation=collation, validate=not bypass_document_validation),
             acknowledged=True)
 
     def replace_one(
@@ -577,7 +602,8 @@ class Collection(object):
         if not bypass_document_validation:
             validate_ok_for_replace(replacement)
         return UpdateResult(
-            self._update(filter, replacement, upsert=upsert, hint=hint, session=session),
+            self._update(filter, replacement, upsert=upsert, hint=hint,
+                         session=session, validate=not bypass_document_validation),
             acknowledged=True)
 
     def update(self, spec, document, upsert=False, manipulate=False,
@@ -589,7 +615,7 @@ class Collection(object):
 
     def _update(self, spec, document, upsert=False, manipulate=False,
                 multi=False, check_keys=False, hint=None, session=None,
-                collation=None, **kwargs):
+                collation=None, validate=True, **kwargs):
         if session:
             raise_not_implemented('session', 'Mongomock does not handle sessions yet')
         if hint:
@@ -855,6 +881,7 @@ class Collection(object):
                         raise ValueError(
                             'Invalid modifier specified: {}'.format(k))
                 first = False
+
             # if empty document comes
             if not document:
                 _id = spec.get('_id', existing_document.get('_id'))
@@ -863,7 +890,7 @@ class Collection(object):
                     existing_document['_id'] = _id
 
             if was_insert:
-                upserted_id = self._insert(existing_document)
+                upserted_id = self._insert(existing_document, validate=validate)
                 num_updated += 1
             elif existing_document != original_document_snapshot:
                 # Document has been modified in-place.
@@ -875,6 +902,27 @@ class Collection(object):
                     raise WriteError(
                         "After applying the update, the (immutable) field '_id' was found to have "
                         'been altered to _id: {}'.format(existing_document.get('_id')))
+
+                if validate:
+                    options = self.options()
+                    validation_level = options.get('validationLevel', 'strict')
+                    if validation_level == 'moderate':
+                        try:
+                            validate_against_validator(original_document_snapshot,
+                                                       options)
+                        except WriteError:
+                            # if validationLevel is 'moderate' and the existing
+                            # document is not valid, we don't have to validate the
+                            # new document
+                            validate = False
+
+                    if validate:
+                        try:
+                            validate_against_validator(existing_document, options)
+                        except WriteError:
+                            # Rollback.
+                            self._store[original_document_snapshot['_id']] = original_document_snapshot
+                            raise
 
                 # Make sure it still respect the unique indexes and, if not, to
                 # revert modifications

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -188,9 +188,14 @@ class Database(object):
                                                                self.name))
         return self[dbref.collection].find_one({'_id': dbref.id})
 
-    def command(self, command, **unused_kwargs):
+    def command(self, command, value=1, check=True, allowable_errors=None,
+                read_preference=None, codec_options=None, session=None,
+                **kwargs):
         if isinstance(command, string_types):
-            command = {command: 1}
+            command = {command: value}
+
+        command.update(kwargs)
+
         if 'ping' in command:
             return {'ok': 1.}
         if 'collMod' in command:

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -154,10 +154,7 @@ class Database(object):
         if name in self.list_collection_names():
             raise CollectionInvalid('collection %s already exists' % name)
 
-        if kwargs:
-            raise NotImplementedError('Special options not supported')
-
-        self._store.create_collection(name)
+        self._store.create_collection(name, **kwargs)
         return self[name]
 
     def rename_collection(self, name, new_name, dropTarget=False):
@@ -196,10 +193,49 @@ class Database(object):
             command = {command: 1}
         if 'ping' in command:
             return {'ok': 1.}
+        if 'collMod' in command:
+            return self._command_collmod(command)
         # TODO(pascal): Differentiate NotImplementedError for valid commands
         # and OperationFailure if the command is not valid.
         raise NotImplementedError(
-            'command is a valid Database method but is not implemented in Mongomock yet')
+            'command is a valid Database method but is not fully implemented '
+            'in Mongomock yet')
+
+    def _command_collmod(self, command):
+        """Implement the collMod database command (partially)."""
+
+        validation_opts = set(['validator', 'validationLevel',
+                               'validationAction'])
+        validation_defaults = {'validationLevel': 'strict',
+                               'validationAction': 'error'}
+
+        coll_name = command.pop('collMod')
+        if coll_name not in self._store:
+            raise OperationFailure('ns does not exist', code=26)
+
+        coll_store = self._store[coll_name]
+        for opt in command:
+            # validate options supported by mongomock
+            if opt not in coll_store._supported_options:
+                raise NotImplementedError(
+                    'setting the {0} option with collMod is not supported '
+                    'in Mongomock yet; supported options are: {1}'.format(
+                        opt, ', '.join(sorted(coll_store.supported_options))))
+
+        # if any of the options are related to validation, collMod
+        # automatically sets defaults for all the validation-related options
+        coll_store.options.update(command)
+        if validation_opts.intersection(command):
+            for k, v in validation_defaults.items():
+                coll_store.options.setdefault(k, v)
+
+        # When setting validator to a trivial validator it is dropped from the
+        # options:
+        if ('validator' in coll_store.options and
+                not coll_store.options['validator']):
+            del coll_store.options['validator']
+
+        return {'ok': 1.0}
 
     def with_options(
             self, codec_options=None, read_preference=None, write_concern=None, read_concern=None):

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -47,9 +47,9 @@ class DatabaseStore(object):
     def list_created_collection_names(self):
         return [name for name, col in self._collections.items() if col.is_created]
 
-    def create_collection(self, name):
+    def create_collection(self, name, **options):
         col = self[name]
-        col.create()
+        col.create(**options)
         return col
 
     def rename(self, name, new_name):
@@ -65,15 +65,27 @@ class DatabaseStore(object):
 class CollectionStore(object):
     """Object holding the data for a collection."""
 
+    _supported_options = set(['validator', 'validationLevel',
+                              'validationAction'])
+
     def __init__(self, name):
         self._documents = collections.OrderedDict()
         self.indexes = {}
+        self.options = {}
         self._is_force_created = False
         self.name = name
         self._ttl_indexes = {}
 
-    def create(self):
+    def create(self, **options):
         self._is_force_created = True
+        for opt in options:
+            if opt not in self._supported_options:
+                raise NotImplementedError(
+                    'the {0} option is not supported; the only currently '
+                    'supported special options are {1}'.format(
+                        opt, ', '.join(sorted(self._supported_options))))
+
+        self.options.update(options)
 
     @property
     def is_created(self):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1975,21 +1975,21 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         # Even setting an empty validator causes the default validation options
         # to be set.
         for db in (fake_db, real_db):
-            self.assertEqual(db.command({'collMod': 'opts1', 'validator': {}}),
+            self.assertEqual(db.command('collMod', 'opts1', validator={}),
                              {'ok': 1.0})
         cmp.compare.options()
 
         # Set a non-empty validator
         for db in (fake_db, real_db):
-            self.assertEqual(db.command({'collMod': 'opts1',
-                                         'validator': {'a': {'$type': 'int'}},
-                                         'validationLevel': 'moderate'}),
+            self.assertEqual(db.command('collMod', 'opts1',
+                                        validator={'a': {'$type': 'int'}},
+                                        validationLevel='moderate'),
                              {'ok': 1.0})
         cmp.compare.options()
 
         # Set the validator empty again
         for db in (fake_db, real_db):
-            self.assertEqual(db.command({'collMod': 'opts1', 'validator': {}}),
+            self.assertEqual(db.command('collMod', 'opts1', validator={}),
                              {'ok': 1.0})
         cmp.compare.options()
 
@@ -2029,8 +2029,8 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         fake_db = self.fake_conn[self.db_name]
         real_db = self.mongo_conn[self.db_name]
         for db in (fake_db, real_db):
-            db.command({'collMod': 'validated_collection',
-                        'validationLevel': 'moderate'})
+            db.command('collMod', 'validated_collection',
+                       validationLevel='moderate')
         cmp.do.update_one({'a': 'bcd'}, {'$set': {'a': 'def'}})
         cmp.compare.find()
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -253,11 +253,22 @@ class _CollectionComparisonTest(TestCase):
             'real': self.mongo_collection,
         })
 
-    def _create_compare_for_collection(self, collection_name, db_name=None):
+    def _create_compare_for_collection(self, collection_name, db_name=None,
+                                       **options):
         if not db_name:
             db_name = self.db_name
-        mongo_collection = self.mongo_conn[db_name][collection_name]
-        fake_collection = self.fake_conn[db_name][collection_name]
+        mongo_db = self.mongo_conn[db_name]
+        fake_db = self.fake_conn[db_name]
+        if collection_name in mongo_db.list_collection_names():
+            mongo_collection = mongo_db[collection_name]
+        else:
+            mongo_collection = mongo_db.create_collection(collection_name,
+                                                          **options)
+        if collection_name in fake_db.list_collection_names():
+            fake_collection = fake_db[collection_name]
+        else:
+            fake_collection = fake_db.create_collection(collection_name,
+                                                        **options)
         return MultiCollection({
             'fake': fake_collection,
             'real': mongo_collection,
@@ -1944,6 +1955,84 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             'three_equal': {'$setEquals': [['one', 'two'], ['two', 'one'], ['one', 'two']]},
             'three_not_equal': {'$setEquals': [['one', 'three'], ['two', 'one'], ['two', 'one']]},
         }}])
+
+    def test__options(self):
+        cmp = self._create_compare_for_collection(
+                'validated_collection',
+                validator={'a': {'$type': 'int'}},
+                validationLevel='strict',
+                validationAction='error')
+        cmp.compare.options()
+
+    def test__validation_options_after_collmod(self):
+        fake_db = self.fake_conn[self.db_name]
+        real_db = self.mongo_conn[self.db_name]
+        cmp = self._create_compare_for_collection('opts1')
+        for db in (fake_db, real_db):
+            self.assertEqual(db.command({'collMod': 'opts1'}), {'ok': 1.0})
+        cmp.compare.options()
+
+        # Even setting an empty validator causes the default validation options
+        # to be set.
+        for db in (fake_db, real_db):
+            self.assertEqual(db.command({'collMod': 'opts1', 'validator': {}}),
+                             {'ok': 1.0})
+        cmp.compare.options()
+
+        # Set a non-empty validator
+        for db in (fake_db, real_db):
+            self.assertEqual(db.command({'collMod': 'opts1',
+                                         'validator': {'a': {'$type': 'int'}},
+                                         'validationLevel': 'moderate'}),
+                             {'ok': 1.0})
+        cmp.compare.options()
+
+        # Set the validator empty again
+        for db in (fake_db, real_db):
+            self.assertEqual(db.command({'collMod': 'opts1', 'validator': {}}),
+                             {'ok': 1.0})
+        cmp.compare.options()
+
+    def test__validate_on_insert(self):
+        cmp = self._create_compare_for_collection(
+                'validated_collection',
+                validator={'a': {'$type': 'int'}},
+                validationLevel='strict',
+                validationAction='error')
+        cmp.do.insert_one({'a': 1})
+        cmp.compare.find()
+        cmp.compare_exceptions.insert_one({'a': 'abc'})
+
+    def test__validate_on_update(self):
+        cmp = self._create_compare_for_collection(
+                'validated_collection', validator={'a': {'$type': 'int'}})
+        # valid document
+        cmp.do.insert_one({'a': 2})
+        cmp.compare.find()
+        cmp.do.update_one({'a': 2}, {'$set': {'a': 1}})
+        cmp.compare.find()
+        cmp.compare_exceptions.update_one({'a': 1}, {'$set': {'a': 'bcd'}})
+        # set it now to an invalid document
+        cmp.do.update_one({'a': 1}, {'$set': {'a': 'bcd'}},
+                          bypass_document_validation=True)
+        cmp.compare.find()
+        # updating a document that does not pass validation fails, unless
+        # updating it to a valid document
+        cmp.compare_exceptions.update_one({'a': 'bcd'}, {'$set': {'a': 'def'}})
+        cmp.do.update_one({'a': 'bcd'}, {'$set': {'a': 1}})
+        cmp.compare.find()
+
+        cmp.do.update_one({'a': 1}, {'$set': {'a': 'bcd'}},
+                          bypass_document_validation=True)
+        # if validationLevel is set to 'moderate', we can update documents that
+        # are already invalid, even if the update leaves it invalid
+        fake_db = self.fake_conn[self.db_name]
+        real_db = self.mongo_conn[self.db_name]
+        for db in (fake_db, real_db):
+            db.command({'collMod': 'validated_collection',
+                        'validationLevel': 'moderate'})
+        cmp.do.update_one({'a': 'bcd'}, {'$set': {'a': 'def'}})
+        cmp.compare.find()
 
 
 @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1958,10 +1958,10 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__options(self):
         cmp = self._create_compare_for_collection(
-                'validated_collection',
-                validator={'a': {'$type': 'int'}},
-                validationLevel='strict',
-                validationAction='error')
+            'validated_collection',
+            validator={'a': {'$type': 'int'}},
+            validationLevel='strict',
+            validationAction='error')
         cmp.compare.options()
 
     def test__validation_options_after_collmod(self):
@@ -1995,17 +1995,17 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
 
     def test__validate_on_insert(self):
         cmp = self._create_compare_for_collection(
-                'validated_collection',
-                validator={'a': {'$type': 'int'}},
-                validationLevel='strict',
-                validationAction='error')
+            'validated_collection',
+            validator={'a': {'$type': 'int'}},
+            validationLevel='strict',
+            validationAction='error')
         cmp.do.insert_one({'a': 1})
         cmp.compare.find()
         cmp.compare_exceptions.insert_one({'a': 'abc'})
 
     def test__validate_on_update(self):
         cmp = self._create_compare_for_collection(
-                'validated_collection', validator={'a': {'$type': 'int'}})
+            'validated_collection', validator={'a': {'$type': 'int'}})
         # valid document
         cmp.do.insert_one({'a': 2})
         cmp.compare.find()


### PR DESCRIPTION
Includes limited support for `Collection.options()` to retrieve validation options on collections, and `Database.command({'collMod': ...})` to support setting validation options on collections.

Now can do, for example:

```python
>>> db.create_collection('coll_name', validator={'a': {'$type': 'int'}})
```

or for an existing collection

```python
>>> db.command({'collMod': 'coll_name', 'validator': {'a': {'$type': 'int'}}})
```

In either case this will reflect in `Collection.options()`:

```python
>>> db.coll_name.options()
{'validator': {'a': {'$type': 'int'}}}
```

With validation enabled, trying to insert (or upsert/update) a document that does not pass validation results in a `WriteError`:

```python
>>> db.coll_name.insert_one({'a': 'abc'})
Traceback (most recent call last):
...
WriteError: Document failed validation
```

This also follows the [documented rules](https://docs.mongodb.com/manual/core/schema-validation/) for the `validationLevel` and `validationAction` options.

Not sure what else this needs in terms of tests--so far it just does the comparison tests.

I have a follow-up PR forthcoming to add `$jsonSchema` support.