### PR TITLE
Support read_concern in database.get_collection()

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -56,7 +56,6 @@ from mongomock import InvalidOperation
 from mongomock.not_implemented import raise_for_feature as raise_not_implemented
 from mongomock import ObjectId
 from mongomock import OperationFailure
-from mongomock.read_concern import ReadConcern
 from mongomock.results import BulkWriteResult
 from mongomock.results import DeleteResult
 from mongomock.results import InsertManyResult
@@ -64,6 +63,11 @@ from mongomock.results import InsertOneResult
 from mongomock.results import UpdateResult
 from mongomock.write_concern import WriteConcern
 from mongomock import WriteError
+
+try:
+    from pymongo.read_concern import ReadConcern
+except ImportError:
+    from mongomock.read_concern import ReadConcern
 
 if hasattr(time, 'perf_counter'):
     _get_perf_counter = time.perf_counter
@@ -79,9 +83,6 @@ _WITH_OPTIONS_KWARGS = {
     'write_concern': _KwargOption(
         'pymongo.write_concern.WriteConcern', WriteConcern(),
         ('acknowledged', 'document')),
-    'read_concern': _KwargOption(
-        'pymongo.read_concern.ReadConcern', ReadConcern(),
-        ('document', 'level', 'ok_for_legacy'))
 }
 
 
@@ -380,6 +381,8 @@ class Collection(object):
         self._name = name
         self._db_store = _db_store
         self._write_concern = write_concern or WriteConcern()
+        if read_concern and not isinstance(read_concern, ReadConcern):
+            raise TypeError('read_concern must be an instance of pymongo.read_concern.ReadConcern')
         self._read_concern = read_concern or ReadConcern()
         self._read_preference = read_preference or _READ_PREFERENCE_PRIMARY
         self._codec_options = codec_options or mongomock_codec_options.CodecOptions()

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -209,11 +209,6 @@ class Database(object):
                 'write_concern is a valid parameter for with_options but is not implemented yet in '
                 'mongomock')
 
-        if read_concern:
-            raise NotImplementedError(
-                'read_concern is a valid parameter for with_options but is not implemented yet in'
-                'mongomock')
-
         if read_preference is None or read_preference == self._read_preference:
             return self
 

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -110,8 +110,6 @@ class Database(object):
 
     def get_collection(self, name, codec_options=None, read_preference=None,
                        write_concern=None, read_concern=None):
-        if read_concern:
-            raise NotImplementedError('Mongomock does not handle read_concern yet')
         if read_preference is not None:
             read_preferences.ensure_read_preference_type('read_preference', read_preference)
         mongomock_codec_options.is_supported(codec_options)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6492,3 +6492,9 @@ class CollectionAPITest(TestCase):
     def test__hashable(self):
         with self.assertRaises(TypeError):
             {self.db.a, self.db.b}  # pylint: disable=pointless-statement
+
+    def test__bad_type_as_a_read_concern_returns_type_error(self):
+        with self.assertRaises(
+            TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
+        ):
+            mongomock.collection.Collection(self.db, "foo", None, read_concern="bar")

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6497,4 +6497,4 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(
             TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
         ):
-            mongomock.collection.Collection(self.db, "foo", None, read_concern="bar")
+            mongomock.collection.Collection(self.db, 'foo', None, read_concern='bar')

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -123,9 +123,6 @@ class DatabaseAPITest(TestCase):
         with self.assertRaises(NotImplementedError):
             self.database.with_options(write_concern=3)
 
-        with self.assertRaises(NotImplementedError):
-            self.database.with_options(read_concern=3)
-
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__with_options_pymongo(self):
         other = self.database.with_options(read_preference=self.database.NEAREST)

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -92,10 +92,6 @@ class DatabaseAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.database.dereference('b')
 
-    def test__get_collection(self):
-        with self.assertRaises(NotImplementedError):
-            self.database.get_collection('a', read_concern=3)
-
     def test__read_preference(self):
         self.assertEqual('Primary', self.database.read_preference.name)
         self.assertEqual(self.database.collection.read_preference, self.database.read_preference)

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -252,7 +252,7 @@ class DatabaseAPITest(TestCase):
         with self.assertRaises(
             TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
         ):
-            mongomock.database.Database(client, "foo", None, read_concern="bar")
+            mongomock.database.Database(client, 'foo', None, read_concern='bar')
 
 
 _DBRef = collections.namedtuple('DBRef', ['database', 'collection', 'id'])

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -5,6 +5,7 @@ import sys
 from unittest import TestCase, skipIf
 
 import mongomock
+from mongomock import read_concern
 
 try:
     from bson import codec_options
@@ -118,6 +119,10 @@ class DatabaseAPITest(TestCase):
     @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
     def test__codec_options(self):
         self.assertEqual(codec_options.CodecOptions(), self.database.codec_options)
+
+    @skipIf(not _HAVE_PYMONGO, 'pymongo not installed')
+    def test__read_concern(self):
+        self.assertEqual(read_concern.ReadConcern(), self.database.read_concern)
 
     def test__with_options(self):
         with self.assertRaises(NotImplementedError):
@@ -241,6 +246,13 @@ class DatabaseAPITest(TestCase):
     def test__hashable(self):
         with self.assertRaises(TypeError):
             {self.database}  # pylint: disable=pointless-statement
+
+    def test__bad_type_as_a_read_concern_returns_type_error(self):
+        client = mongomock.MongoClient()
+        with self.assertRaises(
+            TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
+        ):
+            mongomock.database.Database(client, "foo", None, read_concern="bar")
 
 
 _DBRef = collections.namedtuple('DBRef', ['database', 'collection', 'id'])


### PR DESCRIPTION
This argument is passed to underlying methods, so effectively is supported, only check removal is required.
