### PR TITLE
Fix for {$size: 1} queries on non-existent fields

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -397,7 +397,7 @@ def _regex(doc_val, regex):
 def _size_op(doc_val, search_val):
     if isinstance(doc_val, (list, tuple, dict)):
         return search_val == len(doc_val)
-    return search_val == 1 if doc_val else 0
+    return search_val == 1 if doc_val and doc_val is not NOTHING else 0
 
 
 def _list_expand(f, negative=False):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -502,11 +502,14 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.insert_one({
             '_id': id,
             'l_string': 1,
-            'l_tuple': ['a', 'b']
+            'l_tuple': ['a', 'b'],
+            'null_field': None
         })
         self.cmp.compare.find({'_id': id})
         self.cmp.compare.find({'_id': id, 'l_string': {'$not': {'$size': 0}}})
         self.cmp.compare.find({'_id': id, 'l_tuple': {'$size': 2}})
+        self.cmp.compare.find({'_id': id, 'missing_field': {'$size': 1}})
+        self.cmp.compare.find({'_id': id, 'null_field': {'$size': 1}})
 
     def test__all_with_other_operators(self):
         objs = [{'list': ['a']}, {'list': ['a', 123]}, {'list': ['a', 123, 'xyz']}]


### PR DESCRIPTION
Closes #710 and looks related to the fixes in #697.

Currently, if a missing field is queried with `{field: {"$size": 1}}`, all documents without that field will match, as `bool(NOTHING)` evaluates to `True`. 

This PR checks explicitly whether the missing field `$size` is `NOTHING` (indicating that the field value could not be parsed as an array, see #697).

The first commit in this PR adds a test for the current bug (so the CI should fail), and the second provides the fix.