### PR TITLE
Adds '$not' as a logical operator, fixing issue #715

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -471,6 +471,7 @@ LOGICAL_OPERATOR_MAP = {
     '$or': lambda d, subq, filter_func: any(filter_func(q, d) for q in subq),
     '$and': lambda d, subq, filter_func: all(filter_func(q, d) for q in subq),
     '$nor': lambda d, subq, filter_func: all(not filter_func(q, d) for q in subq),
+    '$not': lambda d, subq, filter_func: (not filter_func(q, d) for q in subq),
 }
 
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -542,6 +542,14 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.insert_one({'_id': 4})
         self.cmp.compare_exceptions.find({'$expr': {'$eq': [{'$size': ['$a']}, 1]}})
 
+    def test_double_negation(self):
+        self.cmp.do.insert_many([
+            {'_id': 1, 'a': 'some str'},
+            {'_id': 2, 'a': 'another str'},
+            {'_id': 3, 'a': []},
+        ])
+        self.cmp.compare.find({'a': {'$not': {'$not': {'$regex': '^some'}}}})
+
     def test__size(self):
         id = ObjectId()
         self.cmp.do.insert_one({


### PR DESCRIPTION
MongoDB correctly processes filters with double negation. For example: {a: {'$not': {'$not': {'$gte': 6}}}} 
This PR adds '$not' as a logical operator, so this now also correctly handled in mongomock. 
I am not yet that experienced with programming in python, so I hope I did everything correctly.