### PR TITLE
Support $objectToArray

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -150,7 +150,8 @@ type_convertion_operators = [
     '$toInt',
     '$toDecimal',
     '$toLong',
-    '$arrayToObject'
+    '$arrayToObject',
+    '$objectToArray',
 ]
 
 
@@ -767,6 +768,23 @@ class _Parser(object):
                 'arrays used with $arrayToObject must contain documents '
                 'with k and v fields or two-element arrays'
             )
+
+        # Document: https://docs.mongodb.com/manual/reference/operator/aggregation/objectToArray/
+        if operator == '$objectToArray':
+            try:
+                parsed = self.parse(values)
+            except KeyError:
+                return None
+
+            if parsed is None:
+                return None
+
+            if not isinstance(parsed, (dict, collections.OrderedDict)):
+                raise OperationFailure(
+                    '$objectToArray requires an object input, found: {}'.format(type(parsed))
+                )
+
+            return [{'k': k, 'v': v} for k, v in parsed.items()]
 
         raise NotImplementedError(
             "Although '%s' is a valid type conversion operator for the "


### PR DESCRIPTION
As I was tinkering with an aggregate pipeline I [found](https://stackoverflow.com/a/52601873) while looking for different ways of getting all properties within a collection, I noticed my tests were failing because `mongomock` doesn't support `$objectToArray` yet.

I tried to implement the function, but I wasn't 100% sure where to put it and how to properly test it.
So please, see this more of a draft or proposal. I will work on it further, but if you like my approach and can nudge me in the right direction, I'd be glad to contribute!

Oh, also, I didn't branch off the latest `develop` but of the last commit that was not failing, hope this is alright!