### PR TITLE
[703] Fix SyntaxWarning where we compare using `is not False`.

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1375,7 +1375,7 @@ def _handle_project_stage(in_collection, unused_database, options):
             except KeyError:
                 # Ignore missing key.
                 pass
-    if (method == 'include') == (include_id is not False and include_id != 0):
+    if (method == 'include') == (include_id != False and include_id != 0):
         filter_list.append('_id')
 
     if not filter_list:


### PR DESCRIPTION
Fixes #703 