### PR TITLE
Support #first and $last in $project (#718)

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -73,6 +73,8 @@ project_operators = [
     '$stdDevPop',
     '$stdDevSamp',
     '$arrayElemAt',
+    '$first',
+    '$last',
 ]
 control_flow_operators = [
     '$switch',
@@ -198,6 +200,8 @@ _GROUPING_OPERATOR_MAP = {
     '$mergeObjects': _merge_objects_operation,
     '$min': lambda values: _group_operation(values, min),
     '$max': lambda values: _group_operation(values, max),
+    '$first': lambda values: values[0] if values else None,
+    '$last': lambda values: values[-1] if values else None,
 }
 
 
@@ -926,10 +930,6 @@ def _accumulate_group(output_fields, group_list):
                     continue
             if operator in _GROUPING_OPERATOR_MAP:
                 doc_dict[field] = _GROUPING_OPERATOR_MAP[operator](values)
-            elif operator == '$first':
-                doc_dict[field] = values[0] if values else None
-            elif operator == '$last':
-                doc_dict[field] = values[-1] if values else None
             elif operator == '$addToSet':
                 value = []
                 val_it = (val or None for val in values)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -3948,6 +3948,28 @@ class CollectionAPITest(TestCase):
         ])
         self.assertEqual([{'a': 3}], list(actual))
 
+    def test__aggregate_project_first(self):
+        self.db.collection.insert_one({'_id': 1, 'arr': [2, 3]})
+        actual = self.db.collection.aggregate([
+            {'$match': {'_id': 1}},
+            {'$project': collections.OrderedDict([
+                ('_id', False),
+                ('a', {'$first': '$arr'})
+            ])}
+        ])
+        self.assertEqual([{'a': 2}], list(actual))
+
+    def test__aggregate_project_last(self):
+        self.db.collection.insert_one({'_id': 1, 'arr': [2, 3]})
+        actual = self.db.collection.aggregate([
+            {'$match': {'_id': 1}},
+            {'$project': collections.OrderedDict([
+                ('_id', False),
+                ('a', {'$last': '$arr'})
+            ])}
+        ])
+        self.assertEqual([{'a': 3}], list(actual))
+
     def test__aggregate_project_rename__id(self):
         self.db.collection.insert_one({'_id': 1, 'arr': [2, 3]})
         actual = self.db.collection.aggregate([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3125,6 +3125,18 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             }}
         ])
 
+    def test__aggregate_first_last_in_array(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            'values': [0, 1, 5]
+        })
+        self.cmp.compare.aggregate([
+            {'$project': {
+                'first': {'$first': '$values'},
+                'last': {'$last': '$values'},
+            }}
+        ])
+
     def test__aggregate_cond_mongodb_to_bool(self):
         """Regression test for bug https://github.com/mongomock/mongomock/issues/650"""
         self.cmp.compare_ignore_order.aggregate([


### PR DESCRIPTION
For aggregation pipelines, support $first and $last as described in docs
https://docs.mongodb.com/manual/reference/operator/aggregation/last-array-element/
https://docs.mongodb.com/manual/reference/operator/aggregation/first-array-element/

This solves some of the issues reported in #718 I guess.
Please review @pcorpet or anyone. Would be grateful as this is blocking testing my project :)
