### PR TITLE
Fix tests using pymongo

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps=
     codecov
     coverage
     mock: mock
-    pymongo: pymongo
+    pymongo: pymongo<4.0
     pymongo361: pymongo==3.6.1
     pyexecjs: pyexecjs
 commands=


### PR DESCRIPTION
By default, pip installs the latest version of pymongo with the previous tox configuration. As pymongo has already released version 4, which contains changes that breaks tests, let's instruct pip to install pymongo<4.0 until we have dealt with the incompatibilities.