### PR TITLE
Implement $indexOfArray and add improvement on other array operators

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -79,7 +79,10 @@ project_operators = [
 control_flow_operators = [
     '$switch',
 ]
-projection_operators = ['$map', '$let', '$literal']
+projection_operators = [
+    '$let',
+    '$literal',
+]
 date_operators = [
     '$dateFromString',
     '$dateToString',
@@ -103,6 +106,7 @@ array_operators = [
     '$filter',
     '$indexOfArray',
     '$isArray',
+    '$map',
     '$range',
     '$reduce',
     '$reverseArray',

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -676,6 +676,66 @@ class _Parser(object):
                 for item in input_array
             ]
 
+        if operator == '$indexOfArray':
+            if not isinstance(value, (list, tuple)):
+                value = [value]
+            if len(value) < 2 or len(value) > 4:
+                raise OperationFailure(
+                    'Expression $indexOfArray takes at least 2 arguments, and '
+                    'at most 4, but %i were passed in.' % len(value)
+                )
+            array_value = self._parse_array_or_nothing(value[0])
+            search_value = self.parse(value[1])
+            start, end = 0, None
+            if len(value) > 2:
+                start = self.parse(value[2])
+            if len(value) > 3:
+                end = self.parse(value[3])
+
+            # Validate arguments
+            if array_value is NOTHING or array_value is None:
+                return None
+            if not isinstance(array_value, list):
+                raise OperationFailure(
+                    '$indexOfArray requires an array as a first argument, '
+                    'found: %s' % type(type(array_value))
+                )
+            if len(value) > 2:
+                if isinstance(start, int):
+                    if start < 0:
+                        raise OperationFailure(
+                            '$indexOfArray requires a nonnegative starting '
+                            'index, found: %r' % start
+                        )
+                else:
+                    raise OperationFailure(
+                        '$indexOfArrayrequires an integral starting index, '
+                        'found a value of type: %s, with value: "%r"' % (
+                            type(start), start
+                        )
+                    )
+            if len(value) > 3:
+                if isinstance(end, int):
+                    if end < 0:
+                        raise OperationFailure(
+                            '$indexOfArray requires a nonnegative ending '
+                            'index, found: %r' % end
+                        )
+                else:
+                    raise OperationFailure(
+                        '$indexOfArrayrequires an integral ending index, '
+                        'found a value of type: %s, with value: "%r"' % (
+                            type(end), end
+                        )
+                    )
+            if end is None:
+                end = len(array_value)
+
+            try:
+                return array_value.index(search_value, start, end)
+            except ValueError:
+                return -1
+
         if operator == '$size':
             if isinstance(value, list):
                 if len(value) != 1:

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -294,6 +294,37 @@ class _Parser(object):
         except KeyError:
             return NOTHING
 
+    def _parse_or_none(self, expression):
+        """Modified version of _parse_or_nothing that returns None instead of NOTHING."""
+        value = self._parse_or_nothing(expression)
+        if value is NOTHING:
+            return None
+        return value
+
+    def _parse_array_or_nothing(self, expression):
+        """Parse expression expected to return an array (which is a list in Python).
+
+        This if the expression is an array literal (list or tuple in Python),
+        then a list with every element parsed is returned. Otherwise, the
+        expression is parsed with _parse_or_nothing().
+
+        Note that is is still possible that the returned value is not a list,
+        so callers must act appropriately for such scenario.
+
+        This is useful for parsing arguments of expressions that are expected
+        to resolve to an array.
+        """
+        if isinstance(expression, (list, tuple)):
+            return [self._parse_or_none(v) for v in expression]
+        return self._parse_or_nothing(expression)
+
+    def _parse_array_or_none(self, expression):
+        """Modified version of _parse_array_or_nothing that returns None instead of NOTHING"""
+        value = self._parse_array_or_nothing(expression)
+        if value is NOTHING:
+            return None
+        return value
+
     def _parse_basic_expression(self, expression):
         if isinstance(expression, six.string_types) and expression.startswith('$'):
             if expression.startswith('$$'):

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1375,7 +1375,7 @@ def _handle_project_stage(in_collection, unused_database, options):
             except KeyError:
                 # Ignore missing key.
                 pass
-    if (method == 'include') == (include_id != False and include_id != 0):
+    if (method == 'include') == (include_id is not False and include_id != 0):
         filter_list.append('_id')
 
     if not filter_list:

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -882,44 +882,66 @@ class _Parser(object):
         if operator == '$in':
             expression, array = values
             return self.parse(expression) in self.parse(array)
-        if operator == '$setUnion':
-            result = []
-            for set_value in values:
-                for value in self.parse(set_value):
-                    if value not in result:
-                        result.append(value)
-            return result
 
-        if operator == '$setIntersection':
+        min_args = {
+            '$setEquals': 2,
+        }
+        accepted_special_values = {
+            '$setUnion': (None, NOTHING),
+            '$setIntersection': (None, NOTHING),
+        }
+        default_result = {
+            '$setEquals': True,
+        }
+        if operator in ('$setUnion', '$setIntersection', '$setEquals'):
             if not isinstance(values, (list, tuple)):
                 values = [values]
+
+            if len(values) < min_args.get(operator, 0):
+                raise OperationFailure(
+                    '%s needs at least two arguments had: %r' % (operator, len(values))
+                )
+
             values = [self._parse_or_nothing(v) for v in values]
-            values = [
-                None if v is NOTHING else v
-                for v in values
-            ]
             for v in values:
-                if not isinstance(v, list) and v is not None:
-                    raise OperationFailure(
-                        'All operands of $setIntersection must be arrays. '
-                        'One argument is of type: %s' % type(v)
-                    )
+                if not isinstance(v, list):
+                    if v not in accepted_special_values.get(operator, []):
+                        type_ = 'missing' if v is NOTHING else type(v)
+                        raise OperationFailure(
+                            'All operands of %s must be arrays. '
+                            'One argument is of type: %s' % (operator, type_)
+                        )
             input_sets = []
             for v in values:
-                if v is None:
+                if v is None or v is NOTHING:
                     input_sets.append(None)
                 else:
                     input_sets.append({helpers.to_hashable(elem) for elem in v})
-            result = set()
+
+            result = default_result.get(operator, set())
+            prev_set = None
             for i, s in enumerate(input_sets):
                 if s is None:
                     result = None
                     break
-                if i == 0:
-                    result = s
+                if operator == '$setUnion':
+                    if i == 0:
+                        result = s
+                    else:
+                        result |= s
+                elif operator == '$setIntersection':
+                    if i == 0:
+                        result = s
+                    else:
+                        result &= s
+                elif operator == '$setEquals':
+                    if i > 0 and s != prev_set:
+                        result = False
+                        break
                 else:
-                    result &= s
-            if result is not None:
+                    raise RuntimeError('unhandled operator %s - this is a bug' % operator)
+                prev_set = s
+            if isinstance(result, set):
                 result = [v.original for v in result]
             return result
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5538,7 +5538,8 @@ class CollectionAPITest(TestCase):
                 'concat_none': {'$concatArrays': None},
                 'concat_missing_field': {'$concatArrays': '$foo'},
                 'concat_none_item': {'$concatArrays': ['$a', None, '$b']},
-                'concat_missing_field_item': {'$concatArrays': [[1, 2, 3], '$c.arr2']}
+                'concat_missing_field_item': {'$concatArrays': [[1, 2, 3], '$c.arr2']},
+                'concat_with_variable_inside': {'$concatArrays': ['$a', ['$a']]},
             }
         }])
         self.assertEqual(
@@ -5549,7 +5550,8 @@ class CollectionAPITest(TestCase):
                 'concat_none': None,
                 'concat_missing_field': None,
                 'concat_none_item': None,
-                'concat_missing_field_item': None
+                'concat_missing_field_item': None,
+                'concat_with_variable_inside': [1, 2, [1, 2]],
             }],
             [{k: v for k, v in doc.items() if k != '_id'} for doc in actual]
         )
@@ -5673,6 +5675,10 @@ class CollectionAPITest(TestCase):
                 'input': '$missing.key',
                 'in': '$$this',
             }},
+            'element_is_missing_type': {'$map': {
+                'input': ['$missing.key', 1],
+                'in': '$$this',
+            }}
         }}])
         expect = [{
             'array': [1, 4, 9, 16],
@@ -5680,6 +5686,7 @@ class CollectionAPITest(TestCase):
             'empty': [],
             'null': None,
             'missing': None,
+            'element_is_missing_type': [None, 1],
         }]
         self.assertEqual(expect, list(actual))
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4473,11 +4473,6 @@ class CollectionAPITest(TestCase):
                 {'$project': {'a': {'$isArray': [1, 2]}}}
             ])
 
-        with self.assertRaises(NotImplementedError):
-            self.db.collection.aggregate([
-                {'$project': {'a': {'$setIntersection': [[2], [1, 2, 3]]}}},
-            ])
-
     def test__aggregate_project_let(self):
         self.db.collection.insert_one({'_id': 1, 'a': 5, 'b': 2, 'c': 3})
         actual = self.db.collection.aggregate([{'$project': {
@@ -5821,6 +5816,77 @@ class CollectionAPITest(TestCase):
             'objects': [{'a': 1}, {'b': 2}, {'c': 3}],
         }]
         self.assertEqual(expect, list(actual))
+
+    def test__set_intersection(self):
+        collection = self.db.collection
+        collection.insert_many([
+            {'array': ['one', 'three']},
+        ])
+        actual = collection.aggregate([{'$project': {
+            '_id': 0,
+            'array': {'$setIntersection': [['one', 'two'], '$array']},
+            'distinct': {'$setIntersection': [['one', 'two'], ['three'], ['four']]},
+            'nested': {'$setIntersection': [['one', 'two'], [['one', 'two']]]},
+            'objects': {'$setIntersection': [[{'a': 1}, {'b': 2}], [{'a': 1}, {'c': 3}]]},
+            'empty': {'$setIntersection': []},
+            'missing': {'$setIntersection': [[1], '$missing.key']},
+            'null': {'$setIntersection': [[1], None]},
+        }}])
+        expect = [{
+            'array': ['one'],
+            'distinct': [],
+            'nested': [],
+            'objects': [{'a': 1}],
+            'empty': [],
+            'missing': None,
+            'null': None,
+        }]
+        self.assertEqual(expect, list(actual))
+
+    @skipIf(sys.version_info < (3, 7), 'dictionaries maintain key order only for Python>=3.7')
+    def test__set_intersection_key_order(self):
+        collection = self.db.collection
+        collection.insert_many([
+            {'array': [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}]},
+        ])
+        actual = collection.aggregate([{'$project': {
+            '_id': 0,
+            'same_order': {'$setIntersection': ['$array', [{'a': 1, 'b': 2}]]},
+            'different_order': {'$setIntersection': ['$array', [{'b': 2, 'a': 1}]]},
+        }}])
+        expect = [{
+            'same_order': [{'a': 1, 'b': 2}],
+            'different_order': [],
+        }]
+        self.assertEqual(expect, list(actual))
+
+    def test__set_intersection_errors(self):
+        collection = self.db.collection
+        collection.insert_many([{}])
+
+        # NOTE: actual types are omitted in the expected message because of
+        # difference in string representations for types between Python 2 and
+        # Python 3.
+        # TODO(guludo): We should output the type name that is output by the
+        # real mongodb.
+        data = (
+            (
+                ['foo'],
+                ('All operands of $setIntersection must be arrays. '
+                 'One argument is of type: ')
+            ),
+            (
+                [98],
+                ('All operands of $setIntersection must be arrays. '
+                 'One argument is of type: ')
+            ),
+        )
+        for operands, msg in data:
+            with self.assertRaises(mongomock.OperationFailure) as cm:
+                collection.aggregate([{'$project': {
+                    'foo': {'$setIntersection': operands},
+                }}])
+            self.assertIn(msg, str(cm.exception))
 
     def test__set_equals(self):
         collection = self.db.collection


### PR DESCRIPTION
**NOTE: this PR depends on #738 and #737, so I'm marking this as a DRAFT until they get applied (hopefully 🙂). I intend to rebase this then (which should reduce the number of commits here).**

Hi there!

This PR implements the operator `$indexOfArray` and also provides some improvement regarding array operators, which should fix #700 and similar issues.

Best regards,
Gustavo Sousa