### PR TITLE
Support 'number' as argument for filter $type

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -492,6 +492,7 @@ TYPE_MAP = {
     'timestamp': None,
     'long': (float,),
     'decimal': (float,),
+    'number': (int, float),
     'minKey': None,
     'maxKey': None,
 }

--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -22,6 +22,11 @@ except ImportError:
     DBRef = None
     _RE_TYPES = (RE_TYPE,)
 
+try:
+    from bson.decimal128 import Decimal128
+except ImportError:
+    Decimal128 = None
+
 _TOP_LEVEL_OPERATORS = {'$expr', '$text', '$where', '$jsonSchema'}
 
 
@@ -410,12 +415,29 @@ def _list_expand(f, negative=False):
     return func
 
 
-def _type_op(doc_val, search_val):
+def _type_op(doc_val, search_val, in_array=False):
     if search_val not in TYPE_MAP:
         raise OperationFailure('%r is not a valid $type' % search_val)
     elif TYPE_MAP[search_val] is None:
         raise NotImplementedError('%s is a valid $type but not implemented' % search_val)
-    return isinstance(doc_val, TYPE_MAP[search_val])
+
+    spec = TYPE_MAP[search_val]
+    if not isinstance(spec, tuple):
+        spec = (spec,)
+
+    for t in spec:
+        if callable(t):
+            if isinstance(t, type):
+                if isinstance(doc_val, t):
+                    return True
+            elif t(doc_val):
+                return True
+        if isinstance(t, str) and _type_op(doc_val, t, in_array):
+            return True
+
+    if isinstance(doc_val, list) and not in_array:
+        return any(_type_op(item, search_val, True) for item in doc_val)
+    return False
 
 
 def _combine_regex_options(search):
@@ -477,7 +499,7 @@ TYPE_MAP = {
     'string': (str,),
     'object': (dict,),
     'array': (list,),
-    'binData': (bytes,),
+    'binData': bytes,
     'undefined': None,
     'objectId': (ObjectId,),
     'bool': (bool,),
@@ -488,11 +510,18 @@ TYPE_MAP = {
     'javascript': None,
     'symbol': None,
     'javascriptWithScope': None,
-    'int': (int,),
+    'int': lambda v: (
+        isinstance(v, int) and not isinstance(v, bool) and v.bit_length() <= 32
+    ),
     'timestamp': None,
-    'long': (float,),
-    'decimal': (float,),
-    'number': (int, float),
+    'long': lambda v: (
+        isinstance(v, int) and not isinstance(v, bool) and v.bit_length() > 32
+    ),
+    'decimal': Decimal128,
+    'number': (
+        ('int', 'long', 'double')
+        + (('decimal',) if Decimal128 is not None else ())
+    ),
     'minKey': None,
     'maxKey': None,
 }

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4538,6 +4538,21 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual(expect, list(actual))
 
+    def test__find_type_number(self):
+        self.db.collection.insert_many([
+            {'_id': 1, 'a': 'str'},
+            {'_id': 2, 'a': 1},
+            {'_id': 3, 'a': {'b': 1}},
+            {'_id': 4, 'a': 1.2},
+            {'_id': 5, 'a': None},
+        ])
+        actual = self.db.collection.find({'a': {'$type': 'number'}})
+        expect = [
+            {'_id': 2, 'a': 1},
+            {'_id': 4, 'a': 1.2},
+        ]
+        self.assertEqual(expect, list(actual))
+
     def test__find_unknown_type(self):
         with self.assertRaises(mongomock.OperationFailure):
             self.db.collection.find_one({'arr': {'$type': 'unknown-type'}})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1013,6 +1013,26 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         # self.cmp.compare.find_one(
         #     {'a': 1}, OrderedDict([('_id', 0), ('a', 0), ('b.c.e', 0), ('b.c', 0)]))
 
+    def test__find_type(self):
+        self.cmp.do.insert_many([
+            {'a': 1.2},  # double
+            {'a': 1},  # int
+            {'a': 1 << 32},  # long
+            {'a': decimal128.Decimal128('1.1')},  # decimal
+            {'a': 'a string value'},  # string
+            {'a': {'b': 1}},  # object
+            {'a': [1, 2, 3]},  # array or int
+            {'a': b'hello'},  # binData
+            {'a': ObjectId()},  # objectId
+            {'a': True},  # bool
+            {'a': datetime.datetime.now()},  # date
+        ])
+        for type_name, spec in mongomock.filtering.TYPE_MAP.items():
+            # Skip unsupported types
+            if spec is None:
+                continue
+            self.cmp.compare.find({'a': {'$type': type_name}})
+
     @skipIf(sys.version_info < (3, 7), 'Older versions of Python cannot copy regex partterns')
     @skipIf(
         helpers.PYMONGO_VERSION >= version.parse('4.0'),


### PR DESCRIPTION
Hi there.

This is a simple PR adding support for `number` as argument for filter operator `$type`, which is an alias grouping numeric types. 

For reference: https://docs.mongodb.com/manual/reference/operator/query/type/. It looks like this is supported by MongoDB from at least version 4.0 (haven't checked documentation for older versions).

Regards,  
Gustavo Sousa