### PR TITLE
Make find(projection=...) return copies of the values

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1175,7 +1175,8 @@ class Collection(object):
                 doc_copy = self._copy_field(doc, container)
         else:
             doc_copy = _project_by_spec(
-                doc, _combine_projection_spec(fields),
+                self._copy_field(doc, container),
+                _combine_projection_spec(fields),
                 is_include=list(fields.values())[0],
                 container=container)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -260,6 +260,14 @@ class CollectionAPITest(TestCase):
         refetched_obj = self.db.collection.find_one({'a': 1})
         self.assertNotEqual(fetched_obj, refetched_obj)
 
+    def test_cursor_with_projection_returns_value_copies(self):
+        self.db.collection.insert_one({'a': ['b']})
+        fetched_list = self.db.collection.find_one(projection=['a'])['a']
+        self.assertEqual(fetched_list, ['b'])
+        fetched_list.append('c')
+        refetched_list = self.db.collection.find_one(projection=['a'])['a']
+        self.assertEqual(refetched_list, ['b'])
+
     @skipIf(helpers.PYMONGO_VERSION >= version.parse('4.0'), 'update was removed in pymongo v4')
     def test__update_retval(self):
         self.db.col.insert_one({'a': 1})


### PR DESCRIPTION
Make sure that the values returned from find() and find_one() when a
projection is specified don't share any references to the actual db
documents.

Fixes #728