### PR TITLE
Fix behavior for $type filter on numeric types

### DIFF
--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1041,6 +1041,34 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         # self.cmp.compare.find_one(
         #     {'a': 1}, OrderedDict([('_id', 0), ('a', 0), ('b.c.e', 0), ('b.c', 0)]))
 
+    def test__find_type(self):
+        supported_types = (
+            'double',
+            'string',
+            'object',
+            'binData',
+            'objectId',
+            'bool',
+            'date',
+            'int',
+            'long',
+            'decimal',
+        )
+        self.cmp.do.insert_many([
+            {'a': 1.2},  # double
+            {'a': 'a string value'},  # string
+            {'a': {'b': 1}},  # object
+            {'a': b'hello'},  # binData
+            {'a': ObjectId()},  # objectId
+            {'a': True},  # bool
+            {'a': datetime.datetime.now()},  # date
+            {'a': 1},  # int
+            {'a': 1 << 32},  # long
+            {'a': decimal128.Decimal128('1.1')},  # decimal
+        ])
+        for type_name in supported_types:
+            self.cmp.compare.find({'a': {'$type': type_name}})
+
     @skipIf(sys.version_info < (3, 7), 'Older versions of Python cannot copy regex partterns')
     @skipIf(
         helpers.PYMONGO_VERSION >= version.parse('4.0'),


### PR DESCRIPTION
Hi there.

This is the first of 3 PRs made from splitting #743.

This makes changes so that we:

- Use correct type for "decimal"
- Ensure that we do not confuse a Python `bool` for an `int` (since
  `isinstance(True, int)` evaluates as True).
- Check on the bit-length of `int` values to check whether they should
  be considered "int" or "long" from Mongo's perspective.

This patch adds the missing test for $type in `test__mongomock.py`. Note
that the "array" type was purposefully ignored from `supported_types`,
as there is an issue that will be solved in a future patch:
`_type_op([1, 2, 3], t)` should return True for both `t = 'array'` and
`t = 'int'`.