### PR TITLE
Add support for "number" alias in $type

### DIFF
--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -508,6 +508,11 @@ TYPE_MAP = {
         isinstance(v, int) and not isinstance(v, bool) and v.bit_length() > 32
     ),
     'decimal': (lambda v: isinstance(v, Decimal128)) if Decimal128 else None,
+    'number': lambda v: (
+        # pylint: disable-next=isinstance-second-argument-not-valid-type
+        isinstance(v, (int, float) + ((Decimal128,) if Decimal128 else ()))
+        and not isinstance(v, bool)
+    ),
     'minKey': None,
     'maxKey': None,
 }

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4588,6 +4588,21 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual(expect, list(actual))
 
+    def test__find_type_number(self):
+        self.db.collection.insert_many([
+            {'_id': 1, 'a': 'str'},
+            {'_id': 2, 'a': 1},
+            {'_id': 3, 'a': {'b': 1}},
+            {'_id': 4, 'a': 1.2},
+            {'_id': 5, 'a': None},
+        ])
+        actual = self.db.collection.find({'a': {'$type': 'number'}})
+        expect = [
+            {'_id': 2, 'a': 1},
+            {'_id': 4, 'a': 1.2},
+        ]
+        self.assertEqual(expect, list(actual))
+
     def test__find_unknown_type(self):
         with self.assertRaises(mongomock.OperationFailure):
             self.db.collection.find_one({'arr': {'$type': 'unknown-type'}})

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1054,6 +1054,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
             'int',
             'long',
             'decimal',
+            'number',
         )
         self.cmp.do.insert_many([
             {'a': 1.2},  # double


### PR DESCRIPTION
This is the third (based on top #756) and final PR made from the split of #743.

Best regards,
Gustavo Sousa