### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,11 @@ author = Rotem Yaari
 author-email = vmalloc@gmail.com
 name = mongomock
 description = Fake pymongo stub for testing simple MongoDB-dependent code
+long_description = file:README.rst
 description-file = README.rst
 license = BSD
+project_urls =
+    Source = https://github.com/mongomock/mongomock
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)