### PR TITLE
Add support for $mergeObjects in $replaceRoot

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -32,7 +32,6 @@ If I miss to include a feature in the below list, Please feel free to add to the
   * Text search operator ($meta)
   * Projection operator $map
   * Array operators ($isArray, $indexOfArray, …)
-  * `$mergeObjects <https://docs.mongodb.com/manual/reference/operator/aggregation/mergeObjects/>`_
   * Some type conversion operators ($convert, …)
 * Operators within the query language (find):
   * `$jsonSchema <https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/>`_

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -254,6 +254,8 @@ class _Parser(object):
                 return self._handle_type_convertion_operator(k, v)
             if k in boolean_operators:
                 return self._handle_boolean_operator(k, v)
+            if k in object_operators:
+                return self._handle_object_operator(k, v)
             if k in text_search_operators + projection_operators + object_operators:
                 raise NotImplementedError(
                     "'%s' is a valid operation but it is not supported by Mongomock yet." % k)
@@ -941,6 +943,15 @@ class _Parser(object):
             return True
         raise NotImplementedError(
             "Although '%s' is a valid set operator for the aggregation "
+            'pipeline, it is currently not implemented in Mongomock.' % operator)
+
+    def _handle_object_operator(self, operator, values):
+        if operator == "$mergeObjects":
+            values = self.parse(values) if isinstance(values, str) else self.parse_many(values)
+            return _merge_objects_operation(values)
+        
+        raise NotImplementedError(
+            "Although '%s' is a valid object operator for the aggregation "
             'pipeline, it is currently not implemented in Mongomock.' % operator)
 
 

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -949,8 +949,9 @@ class _Parser(object):
         if operator == "$mergeObjects":
             values = self.parse(values) if isinstance(values, str) else self.parse_many(values)
             return _merge_objects_operation(values)
-        
-        raise NotImplementedError(
+
+        # This should never happen: it is only a safe fallback if something went wrong.
+        raise NotImplementedError( # pragma: no cover
             "Although '%s' is a valid object operator for the aggregation "
             'pipeline, it is currently not implemented in Mongomock.' % operator)
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -4302,6 +4302,8 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
 
         pipeline = [
             {'$addFields': {'b': '$a'}},
+        ]
+        self.cmp.compare_ignore_order.aggregate(pipeline)
 
 @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
 class MongoClientGraphLookupTest(_CollectionComparisonTest):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3956,6 +3956,34 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         ]
         self.cmp.compare_ignore_order.aggregate(pipeline)
 
+    def test__aggregate_merge_objects_replace_root(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_many([
+            {'_id': ObjectId(),
+             'a': { 'a': '1' }, 'b': {'c': '1', 'd': 2}},
+            {'_id': ObjectId(),
+             'a': { 'a': '1' }, 'b': {'e': 3, 'f': '4'}},
+            {'_id': ObjectId(),
+             'a': { 'a': '1' }, 'c': '2'},
+            {'_id': ObjectId(),
+             'a': { 'a': '1' }, 'b': None},
+            {'_id': ObjectId(),
+             'a': { 'a': 2 }, 'b': None},
+            {'_id': ObjectId(),
+             'a': { 'a': 2 }, 'b': {'c': None, 'd': 6}},
+            {'_id': ObjectId(),
+             'a': { 'a': 2 }, 'b': {'c': '7', 'd': None, 'e': 9, 'f': '10'}},
+            {'_id': ObjectId(),
+             'a': { 'a': 3 }, 'b': None},
+            {'_id': ObjectId(),
+             'a': { 'a': 3 }, 'b': dict()},
+            {'_id': ObjectId(),
+             'a': { 'a': 4 }, 'b': None},
+        ])
+        pipeline = [
+            { '$replaceRoot': { 'newRoot': { '$mergeObjects': [ '$a', '$b' ] } } }
+        ]
+        self.cmp.compare_ignore_order.aggregate(pipeline)
 
 @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
 class MongoClientGraphLookupTest(_CollectionComparisonTest):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3960,30 +3960,31 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         self.cmp.do.drop()
         self.cmp.do.insert_many([
             {'_id': ObjectId(),
-             'a': { 'a': '1' }, 'b': {'c': '1', 'd': 2}},
+             'a': {'a': '1'}, 'b': {'c': '1', 'd': 2}},
             {'_id': ObjectId(),
-             'a': { 'a': '1' }, 'b': {'e': 3, 'f': '4'}},
+             'a': {'a': '1'}, 'b': {'e': 3, 'f': '4'}},
             {'_id': ObjectId(),
-             'a': { 'a': '1' }, 'c': '2'},
+             'a': {'a': '1'}, 'c': '2'},
             {'_id': ObjectId(),
-             'a': { 'a': '1' }, 'b': None},
+             'a': {'a': '1'}, 'b': None},
             {'_id': ObjectId(),
-             'a': { 'a': 2 }, 'b': None},
+             'a': {'a': 2}, 'b': None},
             {'_id': ObjectId(),
-             'a': { 'a': 2 }, 'b': {'c': None, 'd': 6}},
+             'a': {'a': 2}, 'b': {'c': None, 'd': 6}},
             {'_id': ObjectId(),
-             'a': { 'a': 2 }, 'b': {'c': '7', 'd': None, 'e': 9, 'f': '10'}},
+             'a': {'a': 2}, 'b': {'c': '7', 'd': None, 'e': 9, 'f': '10'}},
             {'_id': ObjectId(),
-             'a': { 'a': 3 }, 'b': None},
+             'a': {'a': 3}, 'b': None},
             {'_id': ObjectId(),
-             'a': { 'a': 3 }, 'b': dict()},
+             'a': {'a': 3}, 'b': dict()},
             {'_id': ObjectId(),
-             'a': { 'a': 4 }, 'b': None},
+             'a': {'a': 4}, 'b': None},
         ])
         pipeline = [
-            { '$replaceRoot': { 'newRoot': { '$mergeObjects': [ '$a', '$b' ] } } }
+            {'$replaceRoot': {'newRoot': {'$mergeObjects': ['$a', '$b']}}}
         ]
         self.cmp.compare_ignore_order.aggregate(pipeline)
+
 
 @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
 class MongoClientGraphLookupTest(_CollectionComparisonTest):


### PR DESCRIPTION
Hi,

A small PR for adding `$mergeObjects` support for `$replaceRoot`.

Docs: https://docs.mongodb.com/manual/reference/operator/aggregation/mergeObjects/