### PR TITLE
WIP: add initial asyncio support

### DIFF
--- a/mongomock/async_proxy.py
+++ b/mongomock/async_proxy.py
@@ -1,0 +1,47 @@
+import asyncio
+from mongomock.collection import Cursor, Collection
+from mongomock.database import Database
+
+
+def _convert_to_async(func):
+    async def inner(*args, **kwargs):
+        await asyncio.sleep(0)
+        ret = func(*args, **kwargs)
+        if isinstance(ret, Cursor):
+            return AsyncCursorProxy(ret)
+        return ret
+    return inner
+
+
+class AsyncMongoMockProxy:
+    def __init__(self, real_obj):
+        self.real_obj = real_obj
+
+    def __getattr__(self, item):
+        attr = getattr(self.real_obj, item)
+        if isinstance(attr, Database):
+            return AsyncMongoMockProxy(attr)
+        if isinstance(attr, Collection):
+            return AsyncCollectionProxy(attr)
+        if isinstance(attr, Cursor):
+            return AsyncCursorProxy(attr)
+        if callable(attr):
+            return _convert_to_async(attr)
+        return attr
+
+
+class AsyncCollectionProxy(AsyncMongoMockProxy):
+    def __call__(self, *args, **kwargs):
+        return self.real_obj(*args, **kwargs)
+
+
+class AsyncCursorProxy(AsyncMongoMockProxy):
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        await asyncio.sleep(0)
+        try:
+            return next(self.real_obj)
+        except StopIteration:
+            raise StopAsyncIteration


### PR DESCRIPTION
Referencing: https://github.com/mongomock/mongomock/issues/244

### Goal

Allow async mongodb APIs to be mocked as well E.g. motor. This does not patch motor itself but only allow mongomock base objects to be injected in an async await function under test

### Prototype

This is a simple implementation for proxy pattern; such that a proxy class is used to expose all the current `Collection`, `Cursor`,  and `Database` object methods as coroutines. Some proxy classes are defined implementing some dunder methods that can make them usable in say `async for`

### Usage Example

```python
import pymongo
from mongomock.async_proxy import AsyncMongoMockProxy

@mongomock.patch(servers="test")
@pytest.mark.asyncio
async def test_asyncio_support():
    client = AsyncMongoMockProxy(pymongo.MongoClient("test"))
    await client.db.collection.insert_one({'name': 'world'})
    await client.db.collection.insert_one({'name': 'hello'})
    cur = await client.db.collection.find({})
    all_items = [item async for item in cur]
    assert all_items[0]['hello'] == 'world'
    # at this point you can inject mongomock client to your test function E.g.
    # assert my_api.my_search(client.db, name="world")
```

--- 
This is not the final form, definitely more work need to be done. @pcorpet Let me know your thoughts and feedback
