### PR TITLE
Improve field validation for documents

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -13,6 +13,7 @@ import warnings
 
 try:
     from bson import json_util, SON, BSON
+    from bson.errors import InvalidDocument
 except ImportError:
     json_utils = SON = BSON = None
 try:
@@ -252,6 +253,22 @@ def _copy_field(obj, container):
             new[key] = _copy_field(value, container)
         return new
     return copy.copy(obj)
+
+
+def _recursive_key_check_null_character(data):
+    for key, value in data.items():
+        if '\0' in key:
+            raise InvalidDocument(f'Field names cannot contain the null character (found: {key})')
+        if isinstance(value, Mapping):
+            _recursive_key_check_null_character(value)
+
+
+def _validate_data_fields(data):
+    _recursive_key_check_null_character(data)
+    for key in data.keys():
+        if key.startswith('$'):
+            raise InvalidDocument(f'Top-level field names cannot start with the "$" sign '
+                                  f'(found: {key})')
 
 
 class BulkOperationBuilder(object):
@@ -502,7 +519,11 @@ class Collection(object):
 
         if BSON:
             # bson validation
-            BSON.encode(data, check_keys=True)
+            check_keys = helpers.PYMONGO_VERSION < version.parse('3.6')
+            if not check_keys:
+                _validate_data_fields(data)
+
+            BSON.encode(data, check_keys=check_keys)
 
         # Like pymongo, we should fill the _id in the inserted dict (odd behavior,
         # but we need to stick to it), so we must patch in-place the data dict
@@ -863,7 +884,10 @@ class Collection(object):
                             existing_document['_id'] = _id
                         if BSON:
                             # bson validation
-                            BSON.encode(document, check_keys=True)
+                            check_keys = helpers.PYMONGO_VERSION < version.parse('3.6')
+                            if not check_keys:
+                                _validate_data_fields(document)
+                            BSON.encode(document, check_keys=check_keys)
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             raise OperationFailure(
@@ -2002,7 +2026,14 @@ def _set_updater(doc, field_name, value):
         value = copy.deepcopy(value)
     if BSON:
         # bson validation
-        BSON.encode({field_name: value}, check_keys=True)
+        check_keys = helpers.PYMONGO_VERSION < version.parse('3.6')
+        if not check_keys:
+            if '\0' in field_name or field_name.startswith('$'):
+                raise InvalidDocument(
+                    f'Field name cannot contain the null character and top-level field name '
+                    f'cannot start with "$" (found: {field_name})'
+                )
+        BSON.encode({field_name: value}, check_keys=check_keys)
     if isinstance(doc, dict):
         doc[field_name] = value
     if isinstance(doc, list):

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -5100,7 +5100,26 @@ class CollectionAPITest(TestCase):
         collection = self.db.collection
         with self.assertRaises(InvalidDocument) as cm:
             collection.insert_one({'$foo': 'bar'})
-        self.assertEqual(str(cm.exception), "key '$foo' must not start with '$'")
+        self.assertEqual(str(cm.exception), 'Top-level field names cannot start with the "$"'
+                                            ' sign (found: $foo)')
+        with self.assertRaises(InvalidDocument):
+            collection.insert_one({'foo': {'foo\0bar': 'bar'}})
+
+    @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
+    def test_update_bson_invalid_encode_type(self):
+        self.db.collection.insert_one({'a': 1})
+        with self.assertRaises(InvalidDocument):
+            self.db.collection.update_one(filter={'a': 1}, update={'$set': {'$a': 2}})
+
+    @skipIf(helpers.PYMONGO_VERSION >= version.parse('3.6'),
+            'pymongo has less strict naming requirements after v3.6')
+    @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
+    def test_insert_bson_special_characters(self):
+        collection = self.db.collection
+        collection.insert_one({'foo.bar.zoo': {'foo.bar': '$zoo'}, 'foo.$bar': 'zoo'})
+        actual = self.db.collection.find_one()
+        assert actual['foo.bar.zoo'] == {'foo.bar': '$zoo'}
+        assert actual['foo.$bar'] == 'zoo'
 
     @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
     def test__update_invalid_encode_type(self):


### PR DESCRIPTION
Starting from mongodb 3.6 field names cannot contain the null character and top-field names cannot start with the dollar sign. Apart form those cases mongodb does permit storage of the dots and dollar signs ([mongodb v3.6](https://www.mongodb.com/docs/v3.6/reference/limits/#naming-restrictions)). Newer versions of mongodb add improved support ([mongodb v4.0](https://www.mongodb.com/docs/v4.0/reference/limits/#naming-restrictions), [mongodb v5.0](https://www.mongodb.com/docs/manual/reference/limits/)).

Fixes: https://github.com/mongomock/mongomock/issues/720
