### PR TITLE
Improve aggregation of missing values

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -376,6 +376,8 @@ class _Parser(object):
             key, value = values
             array = self._parse_basic_expression(key)
             index = self.parse(value)
+            if array is NOTHING or index is NOTHING:
+                return None
             try:
                 return array[index]
             except IndexError as error:

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -258,7 +258,7 @@ class _Parser(object):
             if k in boolean_operators:
                 return self._handle_boolean_operator(k, v)
             if k in text_search_operators + projection_operators + object_operators:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     "'%s' is a valid operation but it is not supported by Mongomock yet." % k)
             if k.startswith('$'):
                 raise OperationFailure("Unrecognized expression '%s'" % k)
@@ -369,9 +369,10 @@ class _Parser(object):
             except IndexError:
                 return NOTHING
 
-        raise NotImplementedError("Although '%s' is a valid project operator for the "
-                                  'aggregation pipeline, it is currently not implemented '
-                                  'in Mongomock.' % operator)
+        raise NotImplementedError(  # pragma: no cover
+            "Although '%s' is a valid project operator for the "
+            'aggregation pipeline, it is currently not implemented '
+            'in Mongomock.' % operator)
 
     def _handle_projection_operator(self, operator, value):
         if operator == '$literal':
@@ -392,9 +393,10 @@ class _Parser(object):
                 self._doc_dict,
                 user_vars=dict(self._user_vars, **user_vars),
             ).parse(value['in'])
-        raise NotImplementedError("Although '%s' is a valid project operator for the "
-                                  'aggregation pipeline, it is currently not implemented '
-                                  'in Mongomock.' % operator)
+        raise NotImplementedError(  # pragma: no cover
+            "Although '%s' is a valid project operator for the "
+            'aggregation pipeline, it is currently not implemented '
+            'in Mongomock.' % operator)
 
     def _handle_comparison_operator(self, operator, values):
         assert len(values) == 2, 'Comparison requires two expressions'
@@ -406,7 +408,7 @@ class _Parser(object):
             return a != b
         if operator in filtering.SORTING_OPERATOR_MAP:
             return filtering.bson_compare(filtering.SORTING_OPERATOR_MAP[operator], a, b)
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid comparison operator for the "
             'aggregation pipeline, it is currently not implemented '
             ' in Mongomock.' % operator)
@@ -552,26 +554,26 @@ class _Parser(object):
                     'that has "format" and "date" field.'
                 )
             if '%L' in out_value['format']:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     'Although %L is a valid date format for the '
                     '$dateToString operator, it is currently not implemented '
                     ' in Mongomock.'
                 )
             if 'onNull' in values:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     'Although onNull is a valid field for the '
                     '$dateToString operator, it is currently not implemented '
                     ' in Mongomock.'
                 )
             if 'timezone' in values.keys():
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     'Although timezone is a valid field for the '
                     '$dateToString operator, it is currently not implemented '
                     ' in Mongomock.'
                 )
             return out_value['date'].strftime(out_value['format'])
 
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid date operator for the "
             'aggregation pipeline, it is currently not implemented '
             ' in Mongomock.' % operator)
@@ -696,7 +698,7 @@ class _Parser(object):
                 start = 0
             return array_value[start:stop]
 
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid array operator for the "
             'aggregation pipeline, it is currently not implemented '
             'in Mongomock.' % operator)
@@ -720,7 +722,7 @@ class _Parser(object):
                 if isinstance(parsed, decimal128.Decimal128):
                     return int(parsed.to_decimal())
                 return int(parsed)
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 'You need to import the pymongo library to support decimal128 type.'
             )
 
@@ -732,14 +734,14 @@ class _Parser(object):
                 if isinstance(parsed, decimal128.Decimal128):
                     return int(parsed.to_decimal())
                 return int(parsed)
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 'You need to import the pymongo library to support decimal128 type.'
             )
 
         # Document: https://docs.mongodb.com/manual/reference/operator/aggregation/toDecimal/
         if operator == '$toDecimal':
             if not decimal_support:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     'You need to import the pymongo library to support decimal128 type.'
                 )
             parsed = self.parse(values)
@@ -805,13 +807,13 @@ class _Parser(object):
                 )
 
             if len(parsed) > 1 and sys.version_info < (3, 6):
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     "Although '%s' is a valid type conversion, it is not implemented for Python 2 "
                     'and Python 3.5 in Mongomock yet.' % operator)
 
             return [{'k': k, 'v': v} for k, v in parsed.items()]
 
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid type conversion operator for the "
             'aggregation pipeline, it is currently not implemented '
             'in Mongomock.' % operator)
@@ -907,7 +909,7 @@ class _Parser(object):
                 if set1 != set2:
                     return False
             return True
-        raise NotImplementedError(
+        raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid set operator for the aggregation "
             'pipeline, it is currently not implemented in Mongomock.' % operator)
 
@@ -956,12 +958,12 @@ def _accumulate_group(output_fields, group_list):
                 else:
                     doc_dict[field].extend(values)
             elif operator in group_operators:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     'Although %s is a valid group operator for the '
                     'aggregation pipeline, it is currently not implemented '
                     'in Mongomock.' % operator)
             else:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     '%s is not a valid group operator for the aggregation '
                     'pipeline. See http://docs.mongodb.org/manual/meta/'
                     'aggregation-quick-reference/ for a complete list of '
@@ -982,24 +984,24 @@ def _fix_sort_key(key_getter):
 def _handle_lookup_stage(in_collection, database, options):
     for operator in ('let', 'pipeline'):
         if operator in options:
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Although '%s' is a valid lookup operator for the "
                 'aggregation pipeline, it is currently not '
                 'implemented in Mongomock.' % operator)
     for operator in ('from', 'localField', 'foreignField', 'as'):
         if operator not in options:
-            raise OperationFailure(
+            raise OperationFailure(  # pragma: no cover
                 "Must specify '%s' field for a $lookup" % operator)
         if not isinstance(options[operator], str):
-            raise OperationFailure(
+            raise OperationFailure(  # pragma: no cover
                 'Arguments to $lookup must be strings')
         if operator in ('as', 'localField', 'foreignField') and \
                 options[operator].startswith('$'):
-            raise OperationFailure(
+            raise OperationFailure(  # pragma: no cover
                 "FieldPath field names may not start with '$'")
         if operator == 'as' and \
                 '.' in options[operator]:
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Although '.' is valid in the 'as' "
                 'parameters for the lookup stage of the aggregation '
                 'pipeline, it is currently not implemented in Mongomock.')
@@ -1063,7 +1065,7 @@ def _handle_graph_lookup_stage(in_collection, database, options):
         if options[operator].startswith('$'):
             raise OperationFailure("FieldPath field names may not start with '$'")
         if operator == 'as' and '.' in options[operator]:
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Although '.' is valid in the '%s' "
                 'parameter for the $graphLookup stage of the aggregation '
                 'pipeline, it is currently not implemented in Mongomock.' % operator)
@@ -1485,19 +1487,19 @@ _PIPELINE_HANDLERS = {
 
 def process_pipeline(collection, database, pipeline, session):
     if session:
-        raise NotImplementedError('Mongomock does not handle sessions yet')
+        raise NotImplementedError('Mongomock does not handle sessions yet')  # pragma: no cover
 
     for stage in pipeline:
         for operator, options in stage.items():
             try:
                 handler = _PIPELINE_HANDLERS[operator]
             except KeyError as err:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     '%s is not a valid operator for the aggregation pipeline. '
                     'See http://docs.mongodb.org/manual/meta/aggregation-quick-reference/ '
                     'for a complete list of valid operators.' % operator) from err
             if not handler:
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     "Although '%s' is a valid operator for the aggregation pipeline, it is "
                     'currently not implemented in Mongomock.' % operator)
             collection = handler(collection, database, options)

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -443,12 +443,8 @@ class _Parser(object):
         if operator == '$split':
             if len(values) != 2:
                 raise OperationFailure('split must have 2 items')
-            try:
-                string = self.parse(values[0])
-                delimiter = self.parse(values[1])
-            except KeyError:
-                return None
-
+            string = self.parse(values[0])
+            delimiter = self.parse(values[1])
             if _is_nullish(string) or _is_nullish(delimiter):
                 return None
             if not isinstance(string, str):
@@ -1369,10 +1365,7 @@ def _handle_replace_root_stage(in_collection, unused_database, options):
     new_root = options['newRoot']
     out_collection = []
     for doc in in_collection:
-        try:
-            new_doc = _parse_expression(new_root, doc, ignore_missing_keys=True)
-        except KeyError:
-            new_doc = NOTHING
+        new_doc = _parse_expression(new_root, doc, ignore_missing_keys=True)
         if not isinstance(new_doc, dict):
             raise OperationFailure(
                 "'newRoot' expression must evaluate to an object, but resulting value was: {}"

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1010,11 +1010,10 @@ def _handle_lookup_stage(in_collection, database, options):
     local_name = options['as']
     foreign_collection = database.get_collection(foreign_name)
     for doc in in_collection:
-        try:
-            query = helpers.get_value_by_dot(doc, local_field)
-        except KeyError:
+        query = helpers.get_value_by_dot(doc, local_field)
+        if query is NOTHING:
             query = None
-        if isinstance(query, list):
+        elif isinstance(query, list):
             query = {'$in': query}
         matches = foreign_collection.find({foreign_field: query})
         doc[local_name] = [foreign_doc for foreign_doc in matches]

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -535,10 +535,10 @@ class Collection(object):
             is_sparse = index.get('sparse')
             find_kwargs = {}
             for key, _ in unique:
-                try:
-                    find_kwargs[key] = helpers.get_value_by_dot(new_data, key)
-                except KeyError:
-                    find_kwargs[key] = None
+                value = helpers.get_value_by_dot(new_data, key)
+                if value is NOTHING:
+                    value = None
+                find_kwargs[key] = value
             if is_sparse and set(find_kwargs.values()) == {None}:
                 continue
             answer_count = len(list(self._iter_documents(find_kwargs)))
@@ -1502,12 +1502,12 @@ class Collection(object):
             for doc in documents_gen:
                 index = []
                 for key, unused_order in index_list:
-                    try:
-                        index.append(helpers.get_value_by_dot(doc, key))
-                    except KeyError:
+                    value = helpers.get_value_by_dot(doc, key)
+                    if value is NOTHING:
                         if is_sparse:
                             continue
-                        index.append(None)
+                        value = None
+                    index.append(value)
                 if is_sparse and not index:
                     continue
                 index = tuple(index)

--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -91,7 +91,7 @@ class _Filterer(object):
                 continue
             if key == '$expr':
                 parse_expression = self.parse_expression[0]
-                if not parse_expression(search, document, ignore_missing_keys=True):
+                if not parse_expression(search, document):
                     return False
                 continue
             if key in _TOP_LEVEL_OPERATORS:
@@ -336,7 +336,7 @@ def bson_compare(op, a, b, can_compare_types=True):
                 return bson_compare(op, item_a, item_b)
         return bson_compare(op, len(a), len(b))
 
-    if isinstance(a, NoneType):
+    if isinstance(a, NoneType) or a is NOTHING:
         return op(0, 0)
 
     # bson handles bytes as binary in python3+:
@@ -357,7 +357,7 @@ def _get_compare_type(val):
     also https://github.com/mongodb/mongo/blob/46b28bb/src/mongo/bson/bsontypes.h#L175
     for canonical values.
     """
-    if isinstance(val, NoneType):
+    if isinstance(val, NoneType) or val is NOTHING:
         return 5
     if isinstance(val, bool):
         return 40

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -371,7 +371,10 @@ def get_value_by_dot(doc, key, can_generate_array=False, ignore_missing_keys=Fal
                 if not can_generate_array:
                     raise KeyError(key_index) from err
                 remaining_key = '.'.join(key_items[key_index:])
-                values = [get_value_by_dot(subdoc, remaining_key, ignore_missing_keys=ignore_missing_keys) for subdoc in result]
+                values = [
+                    get_value_by_dot(subdoc, remaining_key, ignore_missing_keys=ignore_missing_keys)
+                    for subdoc in result
+                ]
                 return [v for v in values if v is not NOTHING]
 
             try:

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -354,39 +354,36 @@ def make_datetime_timezone_aware_in_document(value):
     return value
 
 
-def get_value_by_dot(doc, key, can_generate_array=False, ignore_missing_keys=False):
+def get_value_by_dot(doc, key, can_generate_array=False):
     """Get dictionary value using dotted key"""
     result = doc
     key_items = key.split('.')
     for key_index, key_item in enumerate(key_items):
         if isinstance(result, dict):
-            if ignore_missing_keys and key_item not in result:
+            if key_item not in result:
                 return NOTHING
             result = result[key_item]
 
         elif isinstance(result, (list, tuple)):
             try:
                 int_key = int(key_item)
-            except ValueError as err:
+            except ValueError:
                 if not can_generate_array:
-                    raise KeyError(key_index) from err
+                    return NOTHING
                 remaining_key = '.'.join(key_items[key_index:])
                 values = [
-                    get_value_by_dot(subdoc, remaining_key, ignore_missing_keys=ignore_missing_keys)
+                    get_value_by_dot(subdoc, remaining_key)
                     for subdoc in result
                 ]
                 return [v for v in values if v is not NOTHING]
 
             try:
                 result = result[int_key]
-            except (ValueError, IndexError) as err:
-                raise KeyError(key_index) from err
-
-        elif ignore_missing_keys:
-            return NOTHING
+            except (ValueError, IndexError):
+                return NOTHING
 
         else:
-            raise KeyError(key_index)
+            return NOTHING
 
     return result
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2620,6 +2620,14 @@ class CollectionAPITest(TestCase):
             self.db.collection.insert_one({'_id': 4})
             list(self.db.collection.find({'$expr': {'$eq': [{'$size': ['$a']}, 1]}}))
 
+        self.db.collection.insert_one({'_id': 5, 'a': None})
+        actual = list(self.db.collection.find({'$expr': {'$eq': [{'$last': '$a'}, 3]}}, None))
+        self.assertEqual([{'_id': 2, 'a': [1, 2, 3]}], actual)
+
+        self.db.collection.insert_one({'_id': 6, 'array': [{'a': 0}, {'a': 1, 'b': 3}]})
+        actual = list(self.db.collection.find({'$expr': {'$not': {'$gt': [{'$last': '$array.b'}, 2]}}}, {'_id': 1}))
+        self.assertEqual([{'_id': i} for i in range(1,6)], actual)
+
     def test__find_or_and(self):
         self.db.collection.insert_many([
             {'x': 1, 'y': 1},

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2625,8 +2625,13 @@ class CollectionAPITest(TestCase):
         self.assertEqual([{'_id': 2, 'a': [1, 2, 3]}], actual)
 
         self.db.collection.insert_one({'_id': 6, 'array': [{'a': 0}, {'a': 1, 'b': 3}]})
-        actual = list(self.db.collection.find({'$expr': {'$not': {'$gt': [{'$last': '$array.b'}, 2]}}}, {'_id': 1}))
-        self.assertEqual([{'_id': i} for i in range(1,6)], actual)
+        actual = list(
+            self.db.collection.find(
+                {'$expr': {'$not': {'$gt': [{'$last': '$array.b'}, 2]}}},
+                {'_id': 1},
+            )
+        )
+        self.assertEqual([{'_id': i} for i in range(1, 6)], actual)
 
     def test__find_or_and(self):
         self.db.collection.insert_many([

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -7,6 +7,8 @@ from mongomock.helpers import parse_uri
 from mongomock.helpers import print_deprecation_warning
 from unittest import TestCase
 
+from sentinels import NOTHING
+
 
 class HashdictTest(TestCase):
     def test__hashdict(self):
@@ -119,7 +121,7 @@ create_uri_spec_tests()
 class ValueByDotTest(TestCase):
 
     def test__get_value_by_dot_missing_key(self):
-        """Test get_value_by_dot raises KeyError when looking for a missing key"""
+        """Test get_value_by_dot returns NOTHING when looking for a missing key"""
         for doc, key in (
                 ({}, 'a'),
                 ({'a': 1}, 'b'),
@@ -128,7 +130,7 @@ class ValueByDotTest(TestCase):
                 ({'a': {'b': 1}}, 'a.c'),
                 ({'a': [{'b': 1}]}, 'a.b'),
                 ({'a': [{'b': 1}]}, 'a.1.b')):
-            self.assertRaises(KeyError, get_value_by_dot, doc, key)
+            self.assertEqual(get_value_by_dot(doc, key), NOTHING)
 
     def test__get_value_by_dot_find_key(self):
         """Test get_value_by_dot when key can be found"""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3262,7 +3262,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         self.cmp.do.drop()
         self.cmp.do.insert_one({})
         self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', 0]}}}])
-        self.cmp.do.insert_one({'a': [1,2,3]})
+        self.cmp.do.insert_one({'a': [1, 2, 3]})
         self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', 0]}}}])
         self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', '$index']}}}])
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3257,6 +3257,15 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             },
         }])
 
+    def test_aggregate_bug_503(self):
+        """Regression test for bug https://github.com/mongomock/mongomock/issues/503."""
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({})
+        self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', 0]}}}])
+        self.cmp.do.insert_one({'a': [1,2,3]})
+        self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', 0]}}}])
+        self.cmp.compare.aggregate([{'$project': {'b': {'$arrayElemAt': ['$a', '$index']}}}])
+
     def test_aggregate_bug_607(self):
         """Regression test for bug https://github.com/mongomock/mongomock/issues/607."""
         self.cmp.do.drop()


### PR DESCRIPTION
Some mongo operators treat null and missing as distinct, while
others treat them as equivalent. Allow mongomock to make the same
distinction by returning the sentinel `NOTHING` when a basic expression
hits a missing field. This allows e.g. `$last` to extract subfields, rather
than raising an uncaught KeyError as it does now.

Fixes #503 as a side-effect, and may supersede #502.