### PR TITLE
$pushall $addToSet dollar operand support 

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -710,10 +710,16 @@ class Collection(object):
                             # create nested attributes if they do not exist
                             subdocument = existing_document
                             for field_part in nested_field_list[:-1]:
+                                if field_part == '$':
+                                    break
                                 if field_part not in subdocument:
                                     subdocument[field_part] = {}
 
                                 subdocument = subdocument[field_part]
+
+                            # get subdocument with $ oprator support
+                            subdocument, _ = self._get_subdocument(
+                                existing_document, spec, nested_field_list)
 
                             # we're pushing a list
                             push_results = []
@@ -791,11 +797,8 @@ class Collection(object):
                                     obj for obj in arr if obj not in value]
                             continue
                         else:
-                            subdocument = existing_document
-                            for nested_field in nested_field_list[:-1]:
-                                if nested_field not in subdocument:
-                                    break
-                                subdocument = subdocument[nested_field]
+                            subdocument, _ = self._get_subdocument(
+                                existing_document, spec, nested_field_list)
 
                             if nested_field_list[-1] in subdocument:
                                 arr = subdocument[nested_field_list[-1]]

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1641,6 +1641,13 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
                 {'$addToSet': {'shirt.color': {'$each': ['green', 'yellow']}}})
             self.cmp.compare.find({'name': 'bob'})
 
+    def test__addToSet_dollar_operand(self):
+        self.cmp.do.delete_many({})
+        self.cmp.do.insert_one({'takes': [{'a': 2, 'tags': []}, {'a': 1, 'tags': [2]}]})
+        self.cmp.do.update_many(
+            {'takes': {'$elemMatch': {'a': 1}}},
+            {'$addToSet': {'takes.$.tags': 3}})
+
     def test__pop(self):
         self.cmp.do.delete_many({})
         self.cmp.do.insert_one({'name': 'bob', 'hat': ['green', 'tall']})
@@ -1784,20 +1791,16 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.do.update_many({'name': 'bob'}, {'$pullAll': {'hat': ['green']}})
         self.cmp.compare.find({'name': 'bob'})
 
-    def test__pullAll_nested_dict(self):
+    def test__pullAll_dollar_operand(self):
         self.cmp.do.delete_many({})
-        self.cmp.do.insert_one(
-            {'name': 'bob', 'hat': {'properties': {'sizes': ['M', 'L', 'XL']}}})
+        self.cmp.do.insert_one({'name': 'bob', 'takes': [
+            {'a': 1, 'tags': [0, 1, 2, 4]},
+            {'a': 2, 'tags': [0, 1, 2, 4]},
+            {'a': 1, 'tags': [0, 1, 4]},
+            {'a': 1, 'tags': [2, 3, 5]}]})
         self.cmp.do.update_many(
-            {'name': 'bob'}, {'$pullAll': {'hat.properties.sizes': ['M']}})
-        self.cmp.compare.find({'name': 'bob'})
-
-        self.cmp.do.delete_many({})
-        self.cmp.do.insert_one(
-            {'name': 'bob', 'hat': {'properties': {'sizes': ['M', 'L', 'XL']}}})
-        self.cmp.do.update_many(
-            {'name': 'bob'},
-            {'$pullAll': {'hat.properties.sizes': ['M', 'L']}})
+            {'name': 'bob', 'takes': {'$elemMatch': {'a': 1}}},
+            {'$pullAll': {'takes.$.tags': [1, 2, 3]}})
         self.cmp.compare.find({'name': 'bob'})
 
     def test__push(self):


### PR DESCRIPTION
This is a takeover of #606 that has gone stale (and I cannot update the branch there).

These operations do not work without the suggested changes:
```
{"$pullAll": {"takes.$.tags": [1, 2, 3]}}
{"$addToSet": {"takes.$.tags": 3}}
```