### PR TITLE
Support date timezone

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -577,8 +577,7 @@ class _Parser(object):
             'pipeline, it is currently not implemented  in Mongomock.' % operator)
 
     def _handle_date_operator(self, operator, values):
-        if isinstance(values, dict) and \
-                collections.Counter(['date', 'timezone']) == collections.Counter(values.keys()):
+        if isinstance(values, dict) and values.keys() == {'date', 'timezone'}:
             value = self.parse(values['date'])
             target_tz = pytz.timezone(values['timezone'])
             out_value = value.replace(tzinfo=pytz.utc).astimezone(target_tz)

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -578,9 +578,9 @@ class _Parser(object):
 
     def _handle_date_operator(self, operator, values):
         if isinstance(values, dict) and \
-                collections.Counter(["date", "timezone"]) == collections.Counter(values.keys()):
-            value = self.parse(values["date"])
-            target_tz = pytz.timezone(values["timezone"])
+                collections.Counter(['date', 'timezone']) == collections.Counter(values.keys()):
+            value = self.parse(values['date'])
+            target_tz = pytz.timezone(values['timezone'])
             out_value = value.replace(tzinfo=pytz.utc).astimezone(target_tz)
         else:
             out_value = self.parse(values)

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -577,7 +577,8 @@ class _Parser(object):
             'pipeline, it is currently not implemented  in Mongomock.' % operator)
 
     def _handle_date_operator(self, operator, values):
-        if isinstance(values, dict) and collections.Counter(["date", "timezone"]) == collections.Counter(values.keys()):
+        if isinstance(values, dict) and \
+                collections.Counter(["date", "timezone"]) == collections.Counter(values.keys()):
             value = self.parse(values["date"])
             target_tz = pytz.timezone(values["timezone"])
             out_value = value.replace(tzinfo=pytz.utc).astimezone(target_tz)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sentinels
 packaging
+pytz

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3564,6 +3564,23 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         })
         self.cmp.compare.find_one()
 
+    def test_aggregate_date_with_timezone(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            'start_date': datetime.datetime(2011, 11, 4, 0, 5, 23)
+        })
+        pipeline = [
+            {
+                '$addFields': {
+                    'year': {'$year': {'date': '$start_date', 'timezone': 'America/New_York'}},
+                    'week': {'$week': {'date': '$start_date', 'timezone': 'America/New_York'}},
+                    'dayOfWeek': {'$dayOfWeek': {'date': '$start_date', 'timezone': 'America/New_York'}},
+                }
+            },
+            {'$project': {'_id': 0}},
+        ]
+        self.cmp.compare.aggregate(pipeline)
+
     def test__aggregate_add_fields(self):
         self.cmp.do.delete_many({})
         self.cmp.do.insert_many([

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3646,9 +3646,15 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         pipeline = [
             {
                 '$addFields': {
-                    'year': {'$year': {'date': '$start_date', 'timezone': 'America/New_York'}},
-                    'week': {'$week': {'date': '$start_date', 'timezone': 'America/New_York'}},
-                    'dayOfWeek': {'$dayOfWeek': {'date': '$start_date', 'timezone': 'America/New_York'}},
+                    'year': {'$year': {
+                        'date': '$start_date', 'timezone': 'America/New_York'}
+                    },
+                    'week': {'$week': {
+                        'date': '$start_date', 'timezone': 'America/New_York'}
+                    },
+                    'dayOfWeek': {'$dayOfWeek': {
+                        'date': '$start_date', 'timezone': 'America/New_York'}
+                    },
                 }
             },
             {'$project': {'_id': 0}},


### PR DESCRIPTION
### What this PR does
- support { date: <dateExpression>, timezone: <tzExpression> } format for date_operators such as [$week](https://www.mongodb.com/docs/manual/reference/operator/aggregation/week/), [$year](https://www.mongodb.com/docs/manual/reference/operator/aggregation/year/)
### related ticket
https://github.com/mongomock/mongomock/issues/783
