### PR TITLE
Add partialFilterExpression parameter to index

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1548,6 +1548,7 @@ class Collection(object):
                 index.document['key'].items(),
                 session=session,
                 expireAfterSeconds=index.document.get('expireAfterSeconds'),
+                partialFilterExpression=index.document.get('partialFilterExpression'),
                 unique=index.document.get('unique', False),
                 sparse=index.document.get('sparse', False),
                 name=index.document.get('name'))


### PR DESCRIPTION
Parameter partialFilterExpression is [not added](https://github.com/mongomock/mongomock/blob/develop/mongomock/collection.py#L1540) to newly created index in mocked collection:
```python
def create_indexes(self, indexes, session=None):
        # ...

        return [
            self.create_index(
                index.document['key'].items(),
                session=session,
                expireAfterSeconds=index.document.get('expireAfterSeconds'),
                unique=index.document.get('unique', False),
                sparse=index.document.get('sparse', False),
                name=index.document.get('name'))
            for index in indexes
        ]
```
 which results in function [_ensure_uniques](https://github.com/mongomock/mongomock/blob/develop/mongomock/collection.py#L529) throwing an error when checking uniqueness:
 ```python
def _ensure_uniques(self, new_data):
        for index in self._store.indexes.values():
            # ...
            unique = index.get('key')
            is_sparse = index.get('sparse')
            partial_filter_expression = index.get('partialFilterExpression')
            # partial_filter_expression is always None
            # ...
            # find_kwargs = ...
            if partial_filter_expression is not None:
                find_kwargs = {'$and': [partial_filter_expression, find_kwargs]}
            answer_count = len(list(self._iter_documents(find_kwargs)))
            if answer_count > 1:
                # raised when two or more objects have the unique key parameter value = `null`
                raise DuplicateKeyError('E11000 Duplicate Key Error', 11000)  
```
