### PR TITLE
Minor modifications to support disk-based stores

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -544,7 +544,7 @@ class Collection(object):
                 continue
             if partial_filter_expression is not None:
                 find_kwargs = {'$and': [partial_filter_expression, find_kwargs]}
-            answer_count = len(list(self._iter_documents(find_kwargs)))
+            answer_count = helpers.count_iter(self._iter_documents(find_kwargs))
             if answer_count > 1:
                 raise DuplicateKeyError('E11000 Duplicate Key Error', 11000)
 
@@ -639,7 +639,7 @@ class Collection(object):
         upserted_id = None
         num_updated = 0
         num_matched = 0
-        for existing_document in itertools.chain(self._iter_documents(spec), [None]):
+        for existing_document in itertools.chain(list(self._iter_documents(spec)), [None]):
             # we need was_insert for the setOnInsert update operation
             was_insert = False
             # the sentinel document means we should do an upsert
@@ -905,6 +905,9 @@ class Collection(object):
                 # Make sure it still respect the unique indexes and, if not, to
                 # revert modifications
                 try:
+                    # Save the updated document in the store as the store may have provided a copy of the
+                    # document rather than a dict that is being mutated in place.
+                    self._store[existing_document['_id']] = existing_document
                     self._ensure_uniques(existing_document)
                     num_updated += 1
                 except DuplicateKeyError:
@@ -1272,7 +1275,7 @@ class Collection(object):
         if self._store.is_empty:
             filter_applies(filter, {})
 
-        return (document for document in list(self._store.documents)
+        return (document for document in self._store.documents
                 if filter_applies(filter, document))
 
     def find_one(self, filter=None, *args, **kwargs):  # pylint: disable=keyword-arg-before-vararg
@@ -1431,7 +1434,7 @@ class Collection(object):
             if filter is None:
                 return len(self._store)
             spec = helpers.patch_datetime_awareness_in_document(filter)
-            return len(list(self._iter_documents(spec)))
+            return helpers.count_iter(self._iter_documents(spec))
 
     def count_documents(self, filter, **kwargs):
         if kwargs.pop('collation', None):
@@ -1456,7 +1459,7 @@ class Collection(object):
             raise OperationFailure("unrecognized field '%s'" % unknown_kwargs.pop())
 
         spec = helpers.patch_datetime_awareness_in_document(filter)
-        doc_num = len(list(self._iter_documents(spec)))
+        doc_num = helpers.count_iter(self._iter_documents(spec))
         count = max(doc_num - skip, 0)
         return count if limit is None else min(count, limit)
 
@@ -1503,7 +1506,7 @@ class Collection(object):
             raise OperationFailure(
                 'Index with name: %s already exists with different options' % index_name)
 
-        # Check that documents already verify the uniquess of this new index.
+        # Check that documents already verify the uniqueness of this new index.
         if is_unique:
             indexed = set()
             indexed_list = []

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -5,6 +5,7 @@ from mongomock import InvalidURI
 from packaging import version
 import re
 import time
+from typing import Iterable
 from urllib.parse import unquote_plus
 import warnings
 
@@ -90,7 +91,7 @@ def create_index_list(key_or_list, direction=None):
     if not isinstance(key_or_list, (list, tuple, abc.Iterable)):
         raise TypeError('if no direction is specified, '
                         'key_or_list must be an instance of list')
-    return key_or_list
+    return list(key_or_list)
 
 
 def gen_index_name(index_list):
@@ -424,3 +425,13 @@ def mongodb_to_bool(value):
     """Converts any value to bool the way MongoDB does it"""
 
     return value not in [False, None, 0]
+
+def count_iter(iterable: Iterable) -> int:
+    """
+    Count the number of entries in an iterable.
+    Note, that this will consume the iterable.
+
+    :param iterable: the iterable to count
+    :return: the number of terms in the iterable
+    """
+    return sum(1 for _ in iterable)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -14,13 +14,16 @@ import warnings
 
 import mongomock
 from mongomock import helpers
+from mongomock import store
 
 try:
     from unittest import mock
+
     _HAVE_MOCK = True
 except ImportError:
     try:
         import mock
+
         _HAVE_MOCK = True
     except ImportError:
         _HAVE_MOCK = False
@@ -41,7 +44,6 @@ except ImportError:
     from mongomock.read_concern import ReadConcern
     from mongomock.write_concern import WriteConcern
     from tests.utils import DBRef
-
 
 warnings.simplefilter('ignore', DeprecationWarning)
 IS_PYPY = platform.python_implementation() != 'CPython'
@@ -4037,6 +4039,7 @@ class CollectionAPITest(TestCase):
                     'default': 'f',
                 }
             }
+
         self.db.collection.insert_one({'_id': 1})
         actual = self.db.collection.aggregate([
             {'$project': {
@@ -4705,7 +4708,7 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(NotImplementedError):
             self.db.collection.find_one({
                 '$where':
-                'function() {return (hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994")}',
+                    'function() {return (hex_md5(this.name) == "9b53e667f30cd329dca1ec9e6a83e994")}',
             })
 
     def test__unwind_no_prefix(self):
@@ -6155,14 +6158,14 @@ class CollectionAPITest(TestCase):
         self.assertNotEqual(
             original_document, stored_document,
             msg='The document is not the same because the date TZ has been stripped of and the '
-            'microseconds truncated.')
+                'microseconds truncated.')
         self.assertNotEqual(
             original_document['date'].timestamp(), stored_document['date'].timestamp())
         self.assertEqual(
             datetime(2000, 1, 1, 10, 30, 30, 12000),
             stored_document['date'],
             msg='The stored document holds a date as timezone naive UTC and without '
-            'microseconds')
+                'microseconds')
 
         # The objects are not linked: modifying the inserted document or the fetched one will
         # have no effect on future retrievals.
@@ -7091,7 +7094,7 @@ class CollectionAPITest(TestCase):
 
     def test__bad_type_as_a_read_concern_returns_type_error(self):
         with self.assertRaises(
-            TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
+                TypeError, msg='read_concern must be an instance of pymongo.read_concern.ReadConcern'
         ):
             mongomock.collection.Collection(self.db, 'foo', None, read_concern='bar')
 
@@ -7108,3 +7111,60 @@ class CollectionAPITest(TestCase):
         col.find()
         with self.assertRaises(TypeError):
             col.find(allow_disk_use=1)
+
+    def test_offline_store(self):
+        """
+        Test a custom store that always returns copies of the documents in a collection
+        (emulating what a disk-based store would do)
+        """
+
+        class ServerStore(store.ServerStore):
+            def __getitem__(self, db_name):
+                try:
+                    return self._databases[db_name]
+                except KeyError:
+                    db = self._databases[db_name] = DatabaseStore()
+                    return db
+
+        class DatabaseStore(store.DatabaseStore):
+            def __getitem__(self, col_name):
+                try:
+                    return self._collections[col_name]
+                except KeyError:
+                    col = self._collections[col_name] = CollectionStore(col_name)
+                    return col
+
+            def rename(self, name, new_name):
+                col = self._collections.pop(name, CollectionStore(new_name))
+                col.name = new_name
+                self._collections[new_name] = col
+
+        class CustomDict(collections.OrderedDict):
+            def __getitem__(self, key):
+                return copy.deepcopy(super().__getitem__(key))
+
+            def values(self):
+                for value in super().values():
+                    yield copy.deepcopy(value)
+
+        class CollectionStore(store.CollectionStore):
+            def __init__(self, name):
+                super().__init__(name)
+                self._documents = CustomDict()
+
+        # Replace the current store
+        self.client = mongomock.MongoClient(_store=ServerStore())
+        self.db = self.client['somedb']
+
+        # Test from update_one
+        insert_result = self.db.collection.insert_one({'a': 1})
+        update_result = self.db.collection.update_one(
+            filter={'a': 1},
+            update={'$set': {'a': 2}}
+        )
+        self.assertEqual(update_result.matched_count, 1)
+        self.assertEqual(update_result.modified_count, 1)
+        self.assertIsNone(update_result.upserted_id)
+        doc = self.db.collection.find_one({'a': 2})
+        self.assertEqual(insert_result.inserted_id, doc['_id'])
+        self.assertEqual(doc['a'], 2)


### PR DESCRIPTION
The main change introduced in this PR is to explicitly assign an updated document to the collection store:

```
self._store[existing_document['_id']] = existing_document
```

This allows me to efficiently implement a disk-based store which always returns in-memory copies of the document dictionary which, therefore, cannot be updated simply by mutating (which is the assumption of the `_update` method).  I recognise this isn't the target use case for `mongomock` but I hope you'll consider adding it as it's a fairly minor change (and touches upon - but doesn't fix - some of the immutability issues discussed in previous PRs e.g. #692 ).

The other changes are really just there to avoid creating a new list just to count the number of matching documents, which is particularly important in my use case but would generally benefit `mongomock` in any case.

Commit msg:
Previously when performing update operations the document dictionary would be updated in-place (and rolled back if need be, say on conflict). This approach makes it difficult to implement a store where the documents are not in-memory, for example, stored on disk.  In this case, the store just returns copies of the real dictionaries and any mutations are not reflected in the real document on disk.  This commit gets around this by saving the mutated dictionary back to the collection once the code is finished updating it.