### PR TITLE
Add $round operator

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -59,6 +59,7 @@ unary_arithmetic_operators = {
     '$log10',
     '$sqrt',
     '$trunc',
+    '$round',
 }
 binary_arithmetic_operators = {
     '$divide',
@@ -359,6 +360,8 @@ class _Parser(object):
                 return math.sqrt(number)
             if operator == '$trunc':
                 return math.trunc(number)
+            if operator == '$round':
+                return round(number)
 
         if operator in binary_arithmetic_operators:
             if not isinstance(values, (tuple, list)):

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -2654,6 +2654,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             'pow': {'$pow': [4, 2]},
             'sqrt': {'$sqrt': 100},
             'trunc': {'$trunc': 8.35},
+            'round': {'$round': 9.51}
         }}]
         self.cmp.compare.aggregate(pipeline)
 
@@ -3719,6 +3720,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         self.cmp.compare_exceptions.aggregate([{'$project': {'c': {'$mod': [5, 3, 1]}}}])
         self.cmp.compare_exceptions.aggregate([{'$project': {'c': {'$sum': []}}}])
         self.cmp.compare_exceptions.aggregate([{'$project': {'c': {'$multiply': []}}}])
+        self.cmp.compare_exceptions.aggregate([{'$project': {'c': {'$round': "12"}}}])
         self.cmp.compare_exceptions.aggregate([{'$project': {'n': {'$add': '$a'}}}])
         self.cmp.compare_exceptions.aggregate(
             [{'$project': {'q': {'$multiply': [1, '$non_existent_key']}}}])


### PR DESCRIPTION
Add [$round](https://www.mongodb.com/docs/manual/reference/operator/aggregation/round) operator.

Like the current `$trunc` implementation, does not support the `{$round: [<number>, <place>]}` syntax and only supports rounding to the nearest integer with the `{$round: <number>}` syntax