### PR TITLE
fix: support $expression for timzezone in aggregate

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -580,7 +580,8 @@ class _Parser(object):
     def _handle_date_operator(self, operator, values):
         if isinstance(values, dict) and values.keys() == {'date', 'timezone'}:
             value = self.parse(values['date'])
-            target_tz = pytz.timezone(values['timezone'])
+            tz = self.parse(values['timezone'])
+            target_tz = pytz.timezone(tz)
             out_value = value.replace(tzinfo=pytz.utc).astimezone(target_tz)
         else:
             out_value = self.parse(values)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3661,6 +3661,32 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         ]
         self.cmp.compare.aggregate(pipeline)
 
+    def test_aggregate_date_with_timezone_expression(self):
+        self.cmp.do.drop()
+        self.cmp.do.insert_one({
+            'start_date': datetime.datetime(2011, 11, 4, 0, 5, 23),
+            'info': {
+                'tmz': 'America/New_York'
+            }
+        })
+        pipeline = [
+            {
+                '$addFields': {
+                    'year': {'$year': {
+                        'date': '$start_date', 'timezone': '$info.tmz'}
+                    },
+                    'week': {'$week': {
+                        'date': '$start_date', 'timezone': '$info.tmz'}
+                    },
+                    'dayOfWeek': {'$dayOfWeek': {
+                        'date': '$start_date', 'timezone': '$info.tmz'}
+                    },
+                }
+            },
+            {'$project': {'_id': 0}},
+        ]
+        self.cmp.compare.aggregate(pipeline)
+
     def test__aggregate_add_fields(self):
         self.cmp.do.delete_many({})
         self.cmp.do.insert_many([


### PR DESCRIPTION
### What this PR does
- This is the following PR of https://github.com/mongomock/mongomock/pull/791
- This will resolve the issue that has $expression in `timezone` field.

### related ticket
https://github.com/mongomock/mongomock/issues/783#issuecomment-1346831812