### PR TITLE
Forward codec options (#793 continuation)

### DIFF
--- a/mongomock/codec_options.py
+++ b/mongomock/codec_options.py
@@ -76,6 +76,13 @@ class CodecOptions(collections.namedtuple('CodecOptions', _FIELDS)):
         opts.update(kwargs)
         return CodecOptions(**opts)
 
+    def to_pymongo(self):
+        if not codec_options:
+            return None
+        return codec_options.CodecOptions(
+            uuid_representation=self.uuid_representation,
+            unicode_decode_error_handler=self.unicode_decode_error_handler)
+
 
 def is_supported(custom_codec_options):
 

--- a/mongomock/codec_options.py
+++ b/mongomock/codec_options.py
@@ -50,8 +50,8 @@ class CodecOptions(collections.namedtuple('CodecOptions', _FIELDS)):
 
         if uuid_representation is None:
             uuid_representation = _DEFAULT_UUID_REPRESENTATION
-        if uuid_representation != _DEFAULT_UUID_REPRESENTATION:
-            raise NotImplementedError('Mongomock does not handle custom uuid_representation yet')
+        #if uuid_representation != _DEFAULT_UUID_REPRESENTATION:
+        #    raise NotImplementedError('Mongomock does not handle custom uuid_representation yet')
 
         if unicode_decode_error_handler not in ('strict', None):
             raise NotImplementedError(

--- a/mongomock/codec_options.py
+++ b/mongomock/codec_options.py
@@ -50,8 +50,6 @@ class CodecOptions(collections.namedtuple('CodecOptions', _FIELDS)):
 
         if uuid_representation is None:
             uuid_representation = _DEFAULT_UUID_REPRESENTATION
-        #if uuid_representation != _DEFAULT_UUID_REPRESENTATION:
-        #    raise NotImplementedError('Mongomock does not handle custom uuid_representation yet')
 
         if unicode_decode_error_handler not in ('strict', None):
             raise NotImplementedError(

--- a/mongomock/codec_options.py
+++ b/mongomock/codec_options.py
@@ -7,8 +7,10 @@ from mongomock import helpers
 
 try:
     from bson import codec_options
+    from pymongo.common import _UUID_REPRESENTATIONS
 except ImportError:
     codec_options = None
+    _UUID_REPRESENTATIONS = None
 
 
 class TypeRegistry(object):
@@ -79,8 +81,13 @@ class CodecOptions(collections.namedtuple('CodecOptions', _FIELDS)):
     def to_pymongo(self):
         if not codec_options:
             return None
+
+        uuid_representation = self.uuid_representation
+        if _UUID_REPRESENTATIONS and isinstance(self.uuid_representation, str):
+            uuid_representation = _UUID_REPRESENTATIONS[uuid_representation]
+
         return codec_options.CodecOptions(
-            uuid_representation=self.uuid_representation,
+            uuid_representation=uuid_representation,
             unicode_decode_error_handler=self.unicode_decode_error_handler)
 
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -870,7 +870,7 @@ class Collection(object):
                             existing_document['_id'] = _id
                         if BSON:
                             # bson validation
-                            BSON.encode(document, check_keys=True)
+                            BSON.encode(document, check_keys=True, codec_options=self._codec_options)
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             raise OperationFailure(
@@ -1266,7 +1266,7 @@ class Collection(object):
             else:
                 return
         field_name = field_name_parts[-1]
-        updater(doc, field_name, field_value)
+        updater(doc, field_name, field_value, codec_options=self._codec_options)
 
     def _iter_documents(self, filter):
         # Validate the filter even if no documents can be returned.
@@ -2012,12 +2012,12 @@ class Cursor(object):
         return self
 
 
-def _set_updater(doc, field_name, value):
+def _set_updater(doc, field_name, value, codec_options = None):
     if isinstance(value, (tuple, list)):
         value = copy.deepcopy(value)
     if BSON:
         # bson validation
-        BSON.encode({field_name: value}, check_keys=True)
+        BSON.encode({field_name: value}, check_keys=True, codec_options=codec_options)
     if isinstance(doc, dict):
         doc[field_name] = value
     if isinstance(doc, list):

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -77,8 +77,11 @@ _WITH_OPTIONS_KWARGS = {
 
 
 def _bson_encode(document, codec_options):
-    if CodecOptions and isinstance(codec_options, CodecOptions):
-        BSON.encode(document, check_keys=True, codec_options=codec_options)
+    if CodecOptions:
+        if isinstance(codec_options, mongomock_codec_options.CodecOptions):
+            codec_options = codec_options.to_pymongo()
+        if isinstance(codec_options, CodecOptions):
+            BSON.encode(document, check_keys=True, codec_options=codec_options)
     else:
         BSON.encode(document, check_keys=True)
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -78,8 +78,7 @@ _WITH_OPTIONS_KWARGS = {
 
 def _bson_encode(document, codec_options):
     if isinstance(codec_options, CodecOptions):
-        BSON.encode(document, check_keys=True,
-                    codec_options=codec_options)
+        BSON.encode(document, check_keys=True, codec_options=codec_options)
     else:
         BSON.encode(document, check_keys=True)
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -13,8 +13,10 @@ import warnings
 
 try:
     from bson import json_util, SON, BSON
+    from bson.codec_options import CodecOptions
 except ImportError:
     json_utils = SON = BSON = None
+    CodecOptions = type(None)
 try:
     import execjs
 except ImportError:
@@ -72,6 +74,14 @@ _WITH_OPTIONS_KWARGS = {
         'pymongo.write_concern.WriteConcern', WriteConcern(),
         ('acknowledged', 'document')),
 }
+
+
+def _bson_encode(document, codec_options):
+    if isinstance(codec_options, CodecOptions):
+        BSON.encode(document, check_keys=True,
+                    codec_options=codec_options)
+    else:
+        BSON.encode(document, check_keys=True)
 
 
 def validate_is_mapping(option, value):
@@ -502,8 +512,7 @@ class Collection(object):
 
         if BSON:
             # bson validation
-            BSON.encode(data, check_keys=True,
-                    codec_options=self._codec_options)
+            _bson_encode(data, self._codec_options)
 
         # Like pymongo, we should fill the _id in the inserted dict (odd behavior,
         # but we need to stick to it), so we must patch in-place the data dict
@@ -870,7 +879,7 @@ class Collection(object):
                             existing_document['_id'] = _id
                         if BSON:
                             # bson validation
-                            BSON.encode(document, check_keys=True, codec_options=self._codec_options)
+                            _bson_encode(document, self.codec_options)
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             raise OperationFailure(
@@ -2012,12 +2021,12 @@ class Cursor(object):
         return self
 
 
-def _set_updater(doc, field_name, value, codec_options = None):
+def _set_updater(doc, field_name, value, codec_options=None):
     if isinstance(value, (tuple, list)):
         value = copy.deepcopy(value)
     if BSON:
         # bson validation
-        BSON.encode({field_name: value}, check_keys=True, codec_options=codec_options)
+        _bson_encode({field_name: value}, codec_options)
     if isinstance(doc, dict):
         doc[field_name] = value
     if isinstance(doc, list):
@@ -2030,12 +2039,12 @@ def _set_updater(doc, field_name, value, codec_options = None):
         doc[field_index] = value
 
 
-def _unset_updater(doc, field_name, value):
+def _unset_updater(doc, field_name, value, codec_options=None):
     if isinstance(doc, dict):
         doc.pop(field_name, None)
 
 
-def _inc_updater(doc, field_name, value):
+def _inc_updater(doc, field_name, value, codec_options=None):
     if isinstance(doc, dict):
         doc[field_name] = doc.get(field_name, 0) + value
 
@@ -2051,17 +2060,17 @@ def _inc_updater(doc, field_name, value):
             doc[field_index] = value
 
 
-def _max_updater(doc, field_name, value):
+def _max_updater(doc, field_name, value, codec_options=None):
     if isinstance(doc, dict):
         doc[field_name] = max(doc.get(field_name, value), value)
 
 
-def _min_updater(doc, field_name, value):
+def _min_updater(doc, field_name, value, codec_options=None):
     if isinstance(doc, dict):
         doc[field_name] = min(doc.get(field_name, value), value)
 
 
-def _pop_updater(doc, field_name, value):
+def _pop_updater(doc, field_name, value, codec_options=None):
     if value not in {1, -1}:
         raise WriteError('$pop expects 1 or -1, found: ' + str(value))
 
@@ -2081,7 +2090,7 @@ def _pop_updater(doc, field_name, value):
         _pop_from_list(doc[field_index], value)
 
 
-def _pop_from_list(list_instance, mongo_pop_value):
+def _pop_from_list(list_instance, mongo_pop_value, codec_options=None):
     if not list_instance:
         return
 
@@ -2091,7 +2100,7 @@ def _pop_from_list(list_instance, mongo_pop_value):
         list_instance.pop(0)
 
 
-def _current_date_updater(doc, field_name, value):
+def _current_date_updater(doc, field_name, value, codec_options=None):
     if isinstance(doc, dict):
         if value == {'$type': 'timestamp'}:
             # TODO(juannyg): get_current_timestamp should also be using helpers utcnow,

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -16,7 +16,7 @@ try:
     from bson.codec_options import CodecOptions
 except ImportError:
     json_utils = SON = BSON = None
-    CodecOptions = type(None)
+    CodecOptions = None
 try:
     import execjs
 except ImportError:
@@ -77,7 +77,7 @@ _WITH_OPTIONS_KWARGS = {
 
 
 def _bson_encode(document, codec_options):
-    if isinstance(codec_options, CodecOptions):
+    if CodecOptions and isinstance(codec_options, CodecOptions):
         BSON.encode(document, check_keys=True, codec_options=codec_options)
     else:
         BSON.encode(document, check_keys=True)

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -502,7 +502,8 @@ class Collection(object):
 
         if BSON:
             # bson validation
-            BSON.encode(data, check_keys=True)
+            BSON.encode(data, check_keys=True,
+                    codec_options=self._codec_options)
 
         # Like pymongo, we should fill the _id in the inserted dict (odd behavior,
         # but we need to stick to it), so we must patch in-place the data dict

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -31,7 +31,7 @@ class MongoClient(object):
 
     def __init__(self, host=None, port=None, document_class=dict,
                  tz_aware=False, connect=True, _store=None, read_preference=None,
-                 **kwargs):
+                 uuidRepresentation=None, **kwargs):
         if host:
             self.host = host[0] if isinstance(host, (list, tuple)) else host
         else:
@@ -39,7 +39,8 @@ class MongoClient(object):
         self.port = port or self.PORT
 
         self._tz_aware = tz_aware
-        self._codec_options = mongomock_codec_options.CodecOptions(tz_aware=tz_aware)
+        self._codec_options = mongomock_codec_options.CodecOptions(
+            tz_aware=tz_aware, uuid_representation=uuidRepresentation)
         self._database_accesses = {}
         self._store = _store or ServerStore()
         self._id = next(self._CONNECTION_ID)

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -149,8 +149,10 @@ class DatabaseAPITest(TestCase):
             self.database.with_options(custom_document_class)
 
         custom_uuid_representation = codec_options.CodecOptions(uuid_representation=4)
-        db = self.database.with_options(custom_uuid_representation)
-        db.yes_hello.insert_one({'_id': uuid4()})
+        db = self.database
+        db.get_collection('yes_hello',
+                          codec_options=custom_uuid_representation).insert_one({'_id': uuid4()})
+        # db.yes_hello.insert_one({'_id': uuid4()})
 
         custom_unicode_error_hander = codec_options.CodecOptions(
             unicode_decode_error_handler='ignore')

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -3,6 +3,7 @@ import datetime
 from packaging import version
 import sys
 from unittest import TestCase, skipIf, skipUnless
+from uuid import uuid4
 
 import mongomock
 from mongomock import helpers
@@ -148,7 +149,8 @@ class DatabaseAPITest(TestCase):
             self.database.with_options(custom_document_class)
 
         custom_uuid_representation = codec_options.CodecOptions(uuid_representation=4)
-        self.database.with_options(custom_uuid_representation)
+        db = self.database.with_options(custom_uuid_representation)
+        db.yes_hello.insert_one({'_id': uuid4()})
 
         custom_unicode_error_hander = codec_options.CodecOptions(
             unicode_decode_error_handler='ignore')

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -144,14 +144,16 @@ class DatabaseAPITest(TestCase):
             tz_aware_db.with_options(codec_options=codec_options.CodecOptions(tz_aware=True)))
 
         custom_document_class = codec_options.CodecOptions(document_class=collections.OrderedDict)
-        self.database.with_options(custom_document_class)
+        with self.assertRaises(NotImplementedError):
+            self.database.with_options(custom_document_class)
 
         custom_uuid_representation = codec_options.CodecOptions(uuid_representation=4)
         self.database.with_options(custom_uuid_representation)
 
         custom_unicode_error_hander = codec_options.CodecOptions(
             unicode_decode_error_handler='ignore')
-        self.database.with_options(custom_unicode_error_hander)
+        with self.assertRaises(NotImplementedError):
+            self.database.with_options(custom_unicode_error_hander)
 
         custom_tzinfo = codec_options.CodecOptions(tz_aware=True, tzinfo=UTCPlus2())
         self.database.with_options(custom_tzinfo)

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -156,7 +156,8 @@ class DatabaseAPITest(TestCase):
             self.database.with_options(custom_unicode_error_hander)
 
         custom_tzinfo = codec_options.CodecOptions(tz_aware=True, tzinfo=UTCPlus2())
-        self.database.with_options(custom_tzinfo)
+        with self.assertRaises(NotImplementedError):
+            self.database.with_options(custom_tzinfo)
 
     @skipIf(
         not helpers.HAVE_PYMONGO or helpers.PYMONGO_VERSION < version.parse('3.8'),

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -150,9 +150,8 @@ class DatabaseAPITest(TestCase):
 
         custom_uuid_representation = codec_options.CodecOptions(uuid_representation=4)
         db = self.database
-        db.get_collection('yes_hello',
-                          codec_options=custom_uuid_representation).insert_one({'_id': uuid4()})
-        # db.yes_hello.insert_one({'_id': uuid4()})
+        col = db.get_collection(
+            'yes_hello', codec_options=custom_uuid_representation).insert_one({'_id': uuid4()})
 
         custom_unicode_error_hander = codec_options.CodecOptions(
             unicode_decode_error_handler='ignore')

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -144,21 +144,17 @@ class DatabaseAPITest(TestCase):
             tz_aware_db.with_options(codec_options=codec_options.CodecOptions(tz_aware=True)))
 
         custom_document_class = codec_options.CodecOptions(document_class=collections.OrderedDict)
-        with self.assertRaises(NotImplementedError):
-            self.database.with_options(custom_document_class)
+        self.database.with_options(custom_document_class)
 
         custom_uuid_representation = codec_options.CodecOptions(uuid_representation=4)
-        with self.assertRaises(NotImplementedError):
-            self.database.with_options(custom_uuid_representation)
+        self.database.with_options(custom_uuid_representation)
 
         custom_unicode_error_hander = codec_options.CodecOptions(
             unicode_decode_error_handler='ignore')
-        with self.assertRaises(NotImplementedError):
-            self.database.with_options(custom_unicode_error_hander)
+        self.database.with_options(custom_unicode_error_hander)
 
         custom_tzinfo = codec_options.CodecOptions(tz_aware=True, tzinfo=UTCPlus2())
-        with self.assertRaises(NotImplementedError):
-            self.database.with_options(custom_tzinfo)
+        self.database.with_options(custom_tzinfo)
 
     @skipIf(
         not helpers.HAVE_PYMONGO or helpers.PYMONGO_VERSION < version.parse('3.8'),


### PR DESCRIPTION
Salut Pascal. :)

I'm trying to use mongomock as a test backend (through [Mongo-Thingy](https://github.com/Refty/mongo-thingy) and [mongomock-motor](https://github.com/michaelkryukov/mongomock_motor)), but the lack of UUID support makes it impossible.

So here is a continuation PR of #793, so that #745 can get closed; it seems like there are quite a few other persons interested in UUID support at this point (cc @Kalbi @elanou @joshuashaffer @jschlyter @Greeengooo @arturmkr @hugo-azevedo).

Looking at your GitHub activity, I seem to understand that you're busy with other things than mongomock at the moment, so I'll do my best to answer ASAP to any kind of feedback.

Thanks for the great library!