### PR TITLE
Change insertion order of keys in data dicts maintained in Collection._store

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -507,7 +507,9 @@ class Collection(object):
         # Like pymongo, we should fill the _id in the inserted dict (odd behavior,
         # but we need to stick to it), so we must patch in-place the data dict
         if '_id' not in data:
-            data['_id'] = ObjectId()
+            # Additionally, pymongo will return a dict where the "_id" field is inserted first, and some libraries
+            # (mongoengine for example) depend on this implementation detail
+            data = {'_id': ObjectId(), **data}
 
         object_id = data['_id']
         if isinstance(object_id, dict):


### PR DESCRIPTION
Some external libraries (mongoengine is one example), depend on the insertion order of the fields in the dict returned by pymongo, specifically in this fix that the "_id" field is first. I've confirmed that this is how pymongo is providing the data.

Incidentally, this also fixes https://github.com/mongomock/mongomock/issues/641