### PR TITLE
Use `importlib.metadata.version` instead of deprecated `pkg_resources` call

### DIFF
--- a/mongomock/__version__.py
+++ b/mongomock/__version__.py
@@ -2,7 +2,7 @@ from platform import python_version_tuple
 
 python_version = python_version_tuple()
 
-if (int(python_version[0]), and int(python_version[1])) >= (3, 8):
+if (int(python_version[0]), int(python_version[1])) >= (3, 8):
     from importlib.metadata import version
     __version__ = version('mongomock')
 else:

--- a/mongomock/__version__.py
+++ b/mongomock/__version__.py
@@ -1,3 +1,10 @@
-import pkg_resources
+from platform import python_version_tuple
 
-__version__ = pkg_resources.get_distribution('mongomock').version
+python_version = python_version_tuple()
+
+if int(python_version[0]) >= 3 and int(python_version[1]) >= 8:
+    from importlib.metadata import version
+    __version__ = version('mongomock')
+else:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution('mongomock').version

--- a/mongomock/__version__.py
+++ b/mongomock/__version__.py
@@ -2,7 +2,7 @@ from platform import python_version_tuple
 
 python_version = python_version_tuple()
 
-if int(python_version[0]) >= 3 and int(python_version[1]) >= 8:
+if (int(python_version[0]), and int(python_version[1])) >= (3, 8):
     from importlib.metadata import version
     __version__ = version('mongomock')
 else:


### PR DESCRIPTION
`pkg_resources` is now deprecated and we see a warning in our CI for its use with mongomock for Python 3.8+.

```
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/mongomock/__init__.py:79: in <module>
    from mongomock.__version__ import __version__
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/mongomock/__version__.py:1: in <module>
    import pkg_resources
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/pkg_resources/__init__.py:121: in <module>
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
E   DeprecationWarning: pkg_resources is deprecated as an API
```

This PR uses the `importlib.metadata.version` when the Python version is 3.8+.