### PR TITLE
Add support to $type operator

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -169,6 +169,7 @@ type_convertion_operators = [
 type_operators = [
     '$isNumber',
     '$isArray',
+    '$type'
 ]
 
 
@@ -944,6 +945,28 @@ class _Parser:
                 return False
             return isinstance(parsed, (tuple, list))
 
+        if operator == '$type':
+            try:
+                parsed = self.parse(values)
+                if isinstance(parsed, bool):
+                    return "bool"
+                elif isinstance(parsed, str):
+                    return "string"
+                elif isinstance(parsed, dict):
+                    return "object"
+                elif isinstance(parsed, (list, tuple)):
+                    return "array"
+                elif parsed is None:
+                    return "null"
+                elif isinstance(parsed, int) and parsed > 2 ** 31 - 1:
+                    return "long"
+                elif isinstance(parsed, int):
+                    return "int"
+            except KeyError:
+                return "missing"
+            raise NotImplementedError(
+                "Type '%s' is not supported yet" % type(parsed)
+            )
         raise NotImplementedError(  # pragma: no cover
             "Although '%s' is a valid type operator for the aggregation pipeline, it is currently "
             'not implemented in Mongomock.' % operator)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6880,6 +6880,42 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual(expect, list(actual))
 
+    def test_aggregate_type(self):
+        collection = self.db.collection
+
+        collection.insert_one(
+            {'_id': 1, 'list': [1, 2, 3], 'tuple': (1, 2, 3), 'string': "lol", "int": 10, "long": 2 ** 32, "bool": True,
+             "object": {}, "null": None})
+
+        expected = [{
+            'list': 'array',
+            'tuple': 'array',
+            'string': 'string',
+            'int': 'int',
+            'long': 'long',
+            'bool': 'bool',
+            'object': 'object',
+            'null': 'null',
+            'missing': 'missing'
+        }]
+
+        actual = collection.aggregate([{
+            "$project": {
+                '_id': False,
+                'list': {'$type': "$list"},
+                'tuple': {'$type': "$tuple"},
+                'string': {'$type': "$string"},
+                'int': {'$type': "$int"},
+                'long': {'$type': "$long"},
+                'bool': {'$type': "$bool"},
+                'object': {'$type': "$object"},
+                'null': {'$type': "$null"},
+                'missing': {'$type': "$object.doesnt_exist"},
+            }
+        }])
+
+        self.assertListEqual(expected, list(actual))
+
     def test_aggregate_project_with_boolean(self):
         collection = self.db.collection
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3176,6 +3176,28 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
                 }}
         ])
 
+    def test__aggregate_type(self):
+        self.cmp.do.insert_one(
+            {
+                '_id': 1, 'list': [1, 2, 3], 'tuple': (1, 2, 3),
+                'empty_list': [], 'empty_tuple': (),
+                'int': 3, 'str': '123', 'bool': True, 'none': None
+            })
+        self.cmp.compare.aggregate([{
+            "$project": {
+                '_id': False,
+                'list': {'$type': "$list"},
+                'tuple': {'$type': "$tuple"},
+                'string': {'$type': "$string"},
+                'int': {'$type': "$int"},
+                'long': {'$type': "$long"},
+                'bool': {'$type': "$bool"},
+                'object': {'$type': "$object"},
+                'null': {'$type': "$null"},
+                'missing': {'$type': "$object.doesnt_exist"},
+            }
+        }])
+
     def test__aggregate_facet(self):
         self.cmp.do.insert_many([
             {'_id': i} for i in range(5)


### PR DESCRIPTION
Added support to mongo's `$type` operator for:
- int
- long
- bool
- string
- object
- null
- missing