### PR TITLE
Add setissubset operator

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1049,6 +1049,18 @@ class _Parser(object):
                 if set1 != set2:
                     return False
             return True
+        if operator == '$setIsSubset':
+            set1, set2 = values
+
+            def parse_set(to_parse):
+                """Convert a given (nested) set to hashable types to check equality"""
+                if isinstance(to_parse, list):
+                    return tuple(parse_set(v) for v in to_parse)
+                if isinstance(to_parse, dict):
+                    return helpers.hashdict({k: parse_set(v) for k, v in to_parse.items()})
+                return to_parse
+
+            return set(parse_set(self.parse(set1))).issubset(set(parse_set(self.parse(set2))))
         raise NotImplementedError(
             "Although '%s' is a valid set operator for the aggregation "
             'pipeline, it is currently not implemented in Mongomock.' % operator)

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -6098,6 +6098,37 @@ class CollectionAPITest(TestCase):
         }]
         self.assertEqual(expect, list(actual))
 
+    def test__set_is_subset(self):
+        collection = self.db.collection
+        collection.insert_many([
+            {
+                'array': ['one', 'three'],
+                'nested_array': [{'a': 'b', 'c': 'd'}]
+            },
+        ])
+        actual = collection.aggregate([{'$project': {
+            '_id': 0,
+            'same_array': {'$setIsSubset': ['$array', '$array']},
+            'eq_array': {'$setIsSubset': [['one', 'three'], '$array']},
+            'ne_array': {'$setIsSubset': [['one', 'two'], '$array']},
+            'eq_in_another_order': {'$setIsSubset': [['one', 'two'], ['two', 'one']]},
+            'ne_in_another_order': {'$setIsSubset': [['one', 'two'], ['three', 'one', 'two']]},
+            'same_nested_array': {'$setIsSubset': ['$nested_array', '$nested_array']},
+            'eq_nested_array': {'$setIsSubset': [[{'a': 'b'}, {'c': 'd'}], [{'a': 'b'}, {'c': 'd'}]]},
+            'ne_nested_array': {'$setIsSubset': [[{'a': 'b'}, {'c': 'e'}], [{'a': 'b'}, {'c': 'd'}]]},
+        }}])
+        expect = [{
+            'same_array': True,
+            'eq_array': True,
+            'ne_array': False,
+            'eq_in_another_order': True,
+            'ne_in_another_order': True,
+            'same_nested_array': True,
+            'eq_nested_array': True,
+            'ne_nested_array': False,
+        }]
+        self.assertEqual(expect, list(actual))
+
     def test__add_to_set_missing_value(self):
         collection = self.db.collection
         collection.insert_many([


### PR DESCRIPTION
Adds a [$setIsSubset](https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIsSubset/) operator.

Hadles nested sets with unhashable types (mongodb allows comparing lists and dicts so we turn those to `helpers.hashdict` and tuples instead).
