### PR TITLE
Fix for #846

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -700,10 +700,10 @@ class Collection(object):
                             # document should be a list append to it
                             if isinstance(value, dict):
                                 if '$each' in value:
-                                    # append the list to the field
-                                    existing_document[field] += [
-                                        obj for obj in list(value['$each'])
-                                        if obj not in existing_document[field]]
+                                    # append the objects to the field
+                                    for obj in list(value['$each']):
+                                        if obj not in existing_document[field]:
+                                            existing_document[field].append(obj)
                                     continue
                             if value not in existing_document[field]:
                                 existing_document[field].append(value)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1666,6 +1666,16 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
                 {'name': 'bob'},
                 {'$addToSet': {'shirt.color': {'$each': ['green', 'yellow']}}})
             self.cmp.compare.find({'name': 'bob'})
+        for _ in range(3):
+            self.cmp.do.update_many(
+                {'name': 'bob'},
+                {'$addToSet': {'tie': {'$each': ['blue', 'blue', 'blue', 'red']}}})
+            self.cmp.compare.find({'name': 'bob'})
+        for _ in range(3):
+            self.cmp.do.update_many(
+                {'name': 'bob'},
+                {'$addToSet': {'buttons': {'$each': [[1, 2, 3], [1, 2, 3], [1, 2, 3], [3, 2, 1]]}}})
+            self.cmp.compare.find({'name': 'bob'})
 
     def test__addToSet_dollar_operand(self):
         self.cmp.do.delete_many({})


### PR DESCRIPTION
This fixes the bug with the `$each` modifier in `$addToSet`. (Closes #846)

Just replacing the list comprehension with a loop seems to be the most straightforward way to solve this issue. 

Other common ways to get unique elements from a `list` are using a `set` or `dict.fromkeys`, but those methods don't work for unhashable types, like `list`s.
