### PR TITLE
Adds support for $unset operator in aggregation (Fixes #740)

### DIFF
--- a/Missing_Features.rst
+++ b/Missing_Features.rst
@@ -22,7 +22,6 @@ If I miss to include a feature in the below list, Please feel free to add to the
   * `$redact <https://docs.mongodb.com/manual/reference/operator/aggregation/redact/>`_
   * `$replaceWith <https://docs.mongodb.com/manual/reference/operator/aggregation/replaceWith/>`_
   * `$sortByCount <https://docs.mongodb.com/manual/reference/operator/aggregation/sortByCount/>`_
-  * `$unset <https://docs.mongodb.com/manual/reference/operator/aggregation/unset/>` _
 * Operators within the aggregate pipeline:
   * Arithmetic operations on dates:
     * `$add <https://docs.mongodb.com/manual/reference/operator/aggregation/add/>`_

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1570,6 +1570,24 @@ def _handle_add_fields_stage(in_collection, unused_database, options):
     return out_collection
 
 
+def _handle_remove_fields_stage(in_collection, unused_database, options):
+    out_collection = in_collection
+    if not options:
+        raise OperationFailure(
+            'Invalid $unset :: caused by :: $unset specification must be a string or an array with at least one field')
+    if not isinstance(options, list | str):
+        raise OperationFailure(
+            'Invalid $unset :: caused by :: specification must be a string or an array')
+
+    if not isinstance(options, list):
+        options = list(options)
+    for option in options:
+        for entry in out_collection:
+            if option in entry:
+                del entry[option]
+    return out_collection
+
+
 def _handle_out_stage(in_collection, database, options):
     # TODO(MetrodataTeam): should leave the origin collection unchanged
     out_collection = database.get_collection(options)
@@ -1635,7 +1653,7 @@ _PIPELINE_HANDLERS = {
     '$skip': lambda c, d, o: c[o:],
     '$sort': _handle_sort_stage,
     '$sortByCount': None,
-    '$unset': None,
+    '$unset': _handle_remove_fields_stage,
     '$unwind': _handle_unwind_stage,
 }
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4624,6 +4624,28 @@ class CollectionAPITest(TestCase):
             self.db.collection.aggregate([
                 {'$project': {'a': {'$literal': False, 'hint': False}}},
             ])
+    def test__aggregate_unset(self):
+        self.db.collection.insert_one({
+            'a': 1.5,
+            'b': 2,
+            'c': 2,
+        })
+        actual = self.db.collection.aggregate([{'$unset': 'a'}])
+        self.assertEqual(
+            [{'b': 2, 'c': 2}],
+            [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
+
+    def test__aggregate_unset_multi(self):
+        self.db.collection.insert_one({
+            'a': 1.5,
+            'b': 2,
+            'c': 2,
+        })
+        actual = self.db.collection.aggregate([{'$unset': ['a', 'b']}])
+        self.assertEqual(
+            [{'c': 2}],
+            [{k: v for k, v in doc.items() if k != '_id'} for doc in actual])
+
 
     def test__find_type_array(self):
         self.db.collection.insert_one({'_id': 1, 'arr': [1, 2]})


### PR DESCRIPTION
This adds support for the [$unset](https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/) aggregation operator. It fixes #740. Built against spec, and checked against a local db implementation and the behavior matched.