### PR TITLE
Add support for `let` and `pipeline` in lookup stage

### DIFF
--- a/mongomock/__version__.py
+++ b/mongomock/__version__.py
@@ -1,3 +1,3 @@
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution('mongomock').version
+__version__ = "0.0.3"

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1174,8 +1174,10 @@ def _replace_values(obj, let_values):
         return [_replace_values(elem, let_values) for elem in obj]
     elif isinstance(obj, str) and obj.startswith('$$'):
         # Replace placeholder with value from let_values, if available
-        key = obj.lstrip("$")  # Remove the leading '$$'
-        return let_values.get(key, obj)  # Return the original string if no replacement found
+        key = obj.lstrip("$").split('.')  # Remove the leading '$$'
+        if len(key) > 1:
+            return let_values.get(key[0], obj).get(key[1])
+        return let_values.get(key[0], obj)  # Return the original string if no replacement found
     else:
         return obj
 

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1142,9 +1142,9 @@ def _replace_values(obj, let_values):
         return {k: _replace_values(v, let_values) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [_replace_values(elem, let_values) for elem in obj]
-    elif isinstance(obj, str) and obj.startswith('$'):
+    elif isinstance(obj, str) and obj.startswith('$$'):
         # Replace placeholder with value from let_values, if available
-        key = obj[1:]  # Remove the leading '$'
+        key = obj.lstrip("$")  # Remove the leading '$$'
         return let_values.get(key, obj)  # Return the original string if no replacement found
     else:
         return obj
@@ -1209,7 +1209,6 @@ def _handle_lookup_stage(in_collection, database, options):
                 query = {'$in': query}
             matches = foreign_collection.find({foreign_field: query})
             doc[local_name] = [foreign_doc for foreign_doc in matches]
-
     return in_collection
 
 

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -1175,7 +1175,8 @@ def _replace_values(obj, let_values):
     elif isinstance(obj, str) and obj.startswith('$$'):
         # Replace placeholder with value from let_values, if available
         key = obj.lstrip("$").split('.')  # Remove the leading '$$'
-        if len(key) > 1:
+        # Get attribute if available
+        if len(key) > 1 and isinstance(let_values.get(key[0], obj), dict):
             return let_values.get(key[0], obj).get(key[1])
         return let_values.get(key[0], obj)  # Return the original string if no replacement found
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,14 @@
 [metadata]
 author = Rotem Yaari
 author_email = vmalloc@gmail.com
-name = mongomock
+name = mongomock-new
 description = Fake pymongo stub for testing simple MongoDB-dependent code
 long_description = file:README.rst
 description_file = README.rst
 license = BSD
+version = 0.0.3
 project_urls =
-    Source = https://github.com/mongomock/mongomock
+    Source = https://github.com/mohamadkhalaj/mongomock
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Add support for `let` and `pipeline` in lookup stage.
Also supports complex let values, like: 
```
"let": {
    "owner": "$owner_id",
    "latest_story_id": {"$last": {"$slice": ["$owner.story", -1]}},
}
```