### PR TITLE
update collection.create_index

### DIFF
--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -87,9 +87,20 @@ def create_index_list(key_or_list, direction=None):
     """
     if isinstance(key_or_list, str):
         return [(key_or_list, direction or ASCENDING)]
+
     if not isinstance(key_or_list, (list, tuple, abc.Iterable)):
         raise TypeError('if no direction is specified, '
                         'key_or_list must be an instance of list')
+    elif version.parse('4.4.0') <= PYMONGO_VERSION:
+        """
+        Since pymongo 4.4.0 setting a direction with field name is optional.
+        It is assumed that in this case a field should be sorted in ASCENDING order:
+        https://pymongo.readthedocs.io/en/4.4.0/api/pymongo/collection.html#pymongo.collection.Collection.create_index
+        """
+        for index, field_config in enumerate(key_or_list):
+            if isinstance(field_config, str) or (isinstance(field_config, tuple) and len(field_config) == 1):
+                key_or_list[index] = (field_config[0], ASCENDING)
+
     return key_or_list
 
 

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -98,7 +98,9 @@ def create_index_list(key_or_list, direction=None):
         https://pymongo.readthedocs.io/en/4.4.0/api/pymongo/collection.html#pymongo.collection.Collection.create_index
         """
         for index, field_config in enumerate(key_or_list):
-            if isinstance(field_config, str) or (isinstance(field_config, tuple) and len(field_config) == 1):
+            if isinstance(field_config, str):
+                key_or_list[index] = (field_config, ASCENDING)
+            elif isinstance(field_config, tuple) and len(field_config) == 1:
                 key_or_list[index] = (field_config[0], ASCENDING)
 
     return key_or_list

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -1424,6 +1424,13 @@ class CollectionAPITest(TestCase):
         with self.assertRaises(TypeError):
             self.db.collection.create_index([('value', 1, 'foo', 'bar')])
 
+    @skipIf(not helpers.PYMONGO_VERSION >= version.parse('4.4.0'), 'pymongo version smaller then 4.4.0')
+    def test__create_index_optional_direction(self):
+        index_name = self.db.collection.create_index([('keyA', 1), 'keyB'])
+        index_information = self.db.collection.index_information()
+
+        self.assertEqual(index_information[index_name], {'key': [('keyA', 1), ('keyB', 1)]})
+
     def test__ttl_index_ignores_record_in_the_future(self):
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=0)
         self.db.collection.insert_one({'value': datetime.utcnow() + timedelta(seconds=100)})


### PR DESCRIPTION
**Summary**
* pymongo version >= 4.4.0 allows setting list of fields with optional direction. (https://pymongo.readthedocs.io/en/4.4.0/api/pymongo/collection.html#pymongo.collection.Collection.create_indexes)
* If no direction is given, ASCENDING will be assumed.

Hey @pcorpet and @mdomke,

first of all, thank you for maintaining mongomock!

Today I've encountered that the current version of mongomock is not aligned with latest pymongo `create_index` behaviour. Not a big deal, but it will be more convienient for applications using pymongo >= 4.4.0 in combination with mongomock not be forced to set direction because mongomock enforces it.

Best David