### PR TITLE
Use pyupgrade to remove legacy syntax

### DIFF
--- a/mongomock/__init__.py
+++ b/mongomock/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
     class OperationFailure(PyMongoError):
 
         def __init__(self, message, code=None, details=None):
-            super(OperationFailure, self).__init__()
+            super().__init__()
             self._message = message
             self._code = code
             self._details = details
@@ -41,7 +41,7 @@ except ImportError:
     class BulkWriteError(OperationFailure):
 
         def __init__(self, results):
-            super(BulkWriteError, self).__init__(
+            super().__init__(
                 'batch op errors occurred', 65, results)
 
 

--- a/mongomock/codec_options.py
+++ b/mongomock/codec_options.py
@@ -12,7 +12,7 @@ except ImportError:
     codec_options = None
 
 
-class TypeRegistry(object):
+class TypeRegistry:
     pass
 
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import collections
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping, MutableMapping
@@ -27,10 +26,10 @@ try:
     from pymongo import ReturnDocument
     _READ_PREFERENCE_PRIMARY = ReadPreference.PRIMARY
 except ImportError:
-    class IndexModel(object):
+    class IndexModel:
         pass
 
-    class ReturnDocument(object):
+    class ReturnDocument:
         BEFORE = False
         AFTER = True
 
@@ -111,7 +110,7 @@ def validate_write_concern_params(**params):
         WriteConcern(**params)
 
 
-class BulkWriteOperation(object):
+class BulkWriteOperation:
     def __init__(self, builder, selector, is_upsert=False):
         self.builder = builder
         self.selector = selector
@@ -205,7 +204,7 @@ def _combine_projection_spec(projection_fields_spec):
             if not isinstance(tmp_spec.get(base_field), dict):
                 if base_field in tmp_spec:
                     raise OperationFailure(
-                        'Path collision at %s remaining portion %s' % (f, new_field))
+                        f'Path collision at {f} remaining portion {new_field}')
                 tmp_spec[base_field] = OrderedDict()
             tmp_spec[base_field][new_field] = v
 
@@ -271,7 +270,7 @@ def _validate_data_fields(data):
                                   f'(found: {key})')
 
 
-class BulkOperationBuilder(object):
+class BulkOperationBuilder:
     def __init__(self, collection, ordered=False, bypass_document_validation=False):
         self.collection = collection
         self.ordered = ordered
@@ -382,7 +381,7 @@ class BulkOperationBuilder(object):
         write_operation.register_remove_op(not just_one, hint=hint)
 
 
-class Collection(object):
+class Collection:
 
     def __init__(
             self, database, name, _db_store, write_concern=None, read_concern=None,
@@ -398,7 +397,7 @@ class Collection(object):
         self._codec_options = codec_options or mongomock_codec_options.CodecOptions()
 
     def __repr__(self):
-        return "Collection({0}, '{1}')".format(self.database, self.name)
+        return f"Collection({self.database}, '{self.name}')"
 
     def __getitem__(self, name):
         return self.database[self.name + '.' + name]
@@ -427,7 +426,7 @@ class Collection(object):
 
     @property
     def full_name(self):
-        return '{0}.{1}'.format(self.database.name, self._name)
+        return f'{self.database.name}.{self._name}'
 
     @property
     def name(self):
@@ -883,7 +882,7 @@ class Collection(object):
                             if key.startswith('$'):
                                 # can't mix modifiers with non-modifiers in
                                 # update
-                                raise ValueError('field names cannot start with $ [{}]'.format(k))
+                                raise ValueError(f'field names cannot start with $ [{k}]')
                         _id = spec.get('_id', existing_document.get('_id'))
                         existing_document.clear()
                         if _id is not None:
@@ -897,13 +896,13 @@ class Collection(object):
                         existing_document.update(self._internalize_dict(document))
                         if existing_document['_id'] != _id:
                             raise OperationFailure(
-                                'The _id field cannot be changed from {0} to {1}'
+                                'The _id field cannot be changed from {} to {}'
                                 .format(existing_document['_id'], _id))
                         break
                     else:
                         # can't mix modifiers with non-modifiers in update
                         raise ValueError(
-                            'Invalid modifier specified: {}'.format(k))
+                            f'Invalid modifier specified: {k}')
                 first = False
             # if empty document comes
             if not document:
@@ -1069,7 +1068,7 @@ class Collection(object):
                     continue
                 if sort_key.startswith('$'):
                     raise NotImplementedError(
-                        'Sorting by {} is not implemented in mongomock yet'.format(sort_key))
+                        f'Sorting by {sort_key} is not implemented in mongomock yet')
                 dataset = iter(sorted(
                     dataset, key=lambda x: filtering.resolve_sort_key(sort_key, x),
                     reverse=sort_direction < 0))
@@ -1084,7 +1083,7 @@ class Collection(object):
             if isinstance(value, dict):
                 for op in value:
                     if op not in allowed_projection_operators:
-                        raise ValueError('Unsupported projection option: {}'.format(op))
+                        raise ValueError(f'Unsupported projection option: {op}')
                 result[key] = value
 
         for key in result:
@@ -1609,8 +1608,7 @@ class Collection(object):
         if not self._store.is_created:
             return
         yield '_id_', {'key': [('_id', 1)]}
-        for name, information in self._store.indexes.items():
-            yield name, information
+        yield from self._store.indexes.items()
 
     def list_indexes(self, session=None):
         if session:
@@ -1816,7 +1814,7 @@ class Collection(object):
             for attr in options.attrs:
                 if not hasattr(value, attr):
                     raise TypeError(
-                        '{} must be an instance of {}'.format(key, options.typename))
+                        f'{key} must be an instance of {options.typename}')
 
         mongomock_codec_options.is_supported(codec_options)
         if codec_options != self.codec_options:
@@ -1864,11 +1862,11 @@ class Collection(object):
             'aggregate_raw_batches method is not implemented in mongomock yet')
 
 
-class Cursor(object):
+class Cursor:
 
     def __init__(self, collection, spec=None, sort=None, projection=None, skip=0, limit=0,
                  collation=None, no_cursor_timeout=False, batch_size=0, session=None):
-        super(Cursor, self).__init__()
+        super().__init__()
         self.collection = collection
         spec = helpers.patch_datetime_awareness_in_document(spec)
         self._spec = spec

--- a/mongomock/command_cursor.py
+++ b/mongomock/command_cursor.py
@@ -1,6 +1,4 @@
-
-
-class CommandCursor(object):
+class CommandCursor:
 
     def __init__(self, collection, curser_info=None, address=None, retrieved=0):
         self._collection = iter(collection)

--- a/mongomock/database.py
+++ b/mongomock/database.py
@@ -28,11 +28,11 @@ _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS = frozenset(['$regex', '$eq', '$ne'])
 def _verify_list_collection_supported_op(keys):
     if set(keys) - _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS:
         raise NotImplementedError(
-            'list collection names filter operator {0} is not implemented yet in mongomock '
-            'allowed operators are {1}'.format(keys, _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS))
+            'list collection names filter operator {} is not implemented yet in mongomock '
+            'allowed operators are {}'.format(keys, _LIST_COLLECTION_FILTER_ALLOWED_OPERATORS))
 
 
-class Database(object):
+class Database:
 
     def __init__(
         self, client, name, _store, read_preference=None, codec_options=None, read_concern=None
@@ -59,7 +59,7 @@ class Database(object):
         return self[attr]
 
     def __repr__(self):
-        return "Database({0}, '{1}')".format(self._client, self.name)
+        return f"Database({self._client}, '{self.name}')"
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -114,7 +114,7 @@ class Database(object):
 
         if filter:
             if not filter.get('name'):
-                raise NotImplementedError('list collection {0} might be valid but is not '
+                raise NotImplementedError('list collection {} might be valid but is not '
                                           'implemented yet in mongomock'.format(filter))
 
             filter = {field_name: {'$eq': filter.get(field_name)}} \
@@ -190,13 +190,13 @@ class Database(object):
         # https://docs.mongodb.com/manual/reference/command/renameCollection/
         if not self._store[name].is_created:
             raise OperationFailure(
-                'The collection "{0}" does not exist.'.format(name), 10026)
+                f'The collection "{name}" does not exist.', 10026)
         if new_name in self._store:
             if dropTarget:
                 self.drop_collection(new_name)
             else:
                 raise OperationFailure(
-                    'The target collection "{0}" already exists'.format(new_name),
+                    f'The target collection "{new_name}" already exists',
                     10027)
         self._store.rename(name, new_name)
         return {'ok': 1}

--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -52,7 +52,7 @@ def filter_applies(search_filter, document):
     return _filterer_inst.apply(search_filter, document)
 
 
-class _Filterer(object):
+class _Filterer:
     """An object to help applying a filter, using the MongoDB query language."""
 
     # This is populated using register_parse_expression further down.
@@ -96,7 +96,7 @@ class _Filterer(object):
                 continue
             if key in _TOP_LEVEL_OPERATORS:
                 raise NotImplementedError(
-                    'The {} operator is not implemented in mongomock yet'.format(key))
+                    f'The {key} operator is not implemented in mongomock yet')
             if key.startswith('$'):
                 raise OperationFailure('unknown top level operator: ' + key)
 
@@ -537,7 +537,7 @@ def resolve_sort_key(key, doc):
     return 1, BsonComparable(value)
 
 
-class BsonComparable(object):
+class BsonComparable:
     """Wraps a value in an BSON like object that can be compared one to another."""
 
     def __init__(self, obj):

--- a/mongomock/gridfs.py
+++ b/mongomock/gridfs.py
@@ -19,10 +19,10 @@ class _MongoMockGridOutCursor(MongoMockCursor):
 
     def __init__(self, collection, *args, **kwargs):
         self.__root_collection = collection
-        super(_MongoMockGridOutCursor, self).__init__(collection.files, *args, **kwargs)
+        super().__init__(collection.files, *args, **kwargs)
 
     def next(self):
-        next_file = super(_MongoMockGridOutCursor, self).next()
+        next_file = super().next()
         return PyMongoGridOut(
             self.__root_collection, file_document=next_file, session=self.session)
 

--- a/mongomock/helpers.py
+++ b/mongomock/helpers.py
@@ -96,7 +96,7 @@ def create_index_list(key_or_list, direction=None):
 def gen_index_name(index_list):
     """Generate an index name based on the list of keys with directions."""
 
-    return u'_'.join(['%s_%s' % item for item in index_list])
+    return '_'.join(['%s_%s' % item for item in index_list])
 
 
 class hashdict(dict):
@@ -126,39 +126,39 @@ class hashdict(dict):
                          for k, v in self.items())
 
     def __repr__(self):
-        return '{0}({1})'.format(
+        return '{}({})'.format(
             self.__class__.__name__,
-            ', '.join('{0}={1}'.format(str(i[0]), repr(i[1])) for i in sorted(self.__key())))
+            ', '.join(f'{str(i[0])}={repr(i[1])}' for i in sorted(self.__key())))
 
     def __hash__(self):
         return hash(self.__key())
 
     def __setitem__(self, key, value):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def __delitem__(self, key):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def clear(self):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def pop(self, *args, **kwargs):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def popitem(self, *args, **kwargs):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def setdefault(self, *args, **kwargs):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def update(self, *args, **kwargs):
-        raise TypeError('{0} does not support item assignment'
+        raise TypeError('{} does not support item assignment'
                         .format(self.__class__.__name__))
 
     def __add__(self, right):

--- a/mongomock/mongo_client.py
+++ b/mongomock/mongo_client.py
@@ -23,7 +23,7 @@ def _convert_version_to_list(version_str):
     return pieces + [0] * (4 - len(pieces))
 
 
-class MongoClient(object):
+class MongoClient:
 
     HOST = 'localhost'
     PORT = 27017
@@ -74,7 +74,7 @@ class MongoClient(object):
         self.close()
 
     def __repr__(self):
-        return "mongomock.MongoClient('{0}', {1})".format(self.host, self.port)
+        return f"mongomock.MongoClient('{self.host}', {self.port})"
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/mongomock/object_id.py
+++ b/mongomock/object_id.py
@@ -1,9 +1,8 @@
 import uuid
 
 
-class ObjectId(object):
+class ObjectId:
     def __init__(self, id=None):
-        super(ObjectId, self).__init__()
         if id is None:
             self._id = uuid.uuid1()
         else:
@@ -19,7 +18,7 @@ class ObjectId(object):
         return hash(self._id)
 
     def __repr__(self):
-        return 'ObjectId({0})'.format(self._id)
+        return f'ObjectId({self._id})'
 
     def __str__(self):
         return str(self._id)

--- a/mongomock/patch.py
+++ b/mongomock/patch.py
@@ -1,15 +1,7 @@
 from .mongo_client import MongoClient
 import time
 
-try:
-    from unittest import mock
-    _IMPORT_MOCK_ERROR = None
-except ImportError:
-    try:
-        import mock
-        _IMPORT_MOCK_ERROR = None
-    except ImportError as error:
-        _IMPORT_MOCK_ERROR = error
+from unittest import mock
 
 try:
     import pymongo
@@ -54,9 +46,6 @@ def patch(servers='localhost', on_new='error'):
             'pymongo': use an actual pymongo client.
         servers: a list of server that are avaiable.
     """
-
-    if _IMPORT_MOCK_ERROR:
-        raise _IMPORT_MOCK_ERROR  # pylint: disable=raising-bad-type
 
     if _IMPORT_PYMONGO_ERROR:
         PyMongoClient = None

--- a/mongomock/read_concern.py
+++ b/mongomock/read_concern.py
@@ -1,4 +1,4 @@
-class ReadConcern(object):
+class ReadConcern:
     def __init__(self, level=None):
         self._document = {}
 

--- a/mongomock/read_preferences.py
+++ b/mongomock/read_preferences.py
@@ -1,4 +1,4 @@
-class _Primary(object):
+class _Primary:
 
     @property
     def mongos_mode(self):

--- a/mongomock/results.py
+++ b/mongomock/results.py
@@ -5,7 +5,7 @@ try:
     from pymongo.results import InsertOneResult
     from pymongo.results import UpdateResult
 except ImportError:
-    class _WriteResult(object):
+    class _WriteResult:
 
         def __init__(self, acknowledged=True):
             self.__acknowledged = acknowledged
@@ -20,7 +20,7 @@ except ImportError:
 
         def __init__(self, inserted_id, acknowledged=True):
             self.__inserted_id = inserted_id
-            super(InsertOneResult, self).__init__(acknowledged)
+            super().__init__(acknowledged)
 
         @property
         def inserted_id(self):
@@ -32,7 +32,7 @@ except ImportError:
 
         def __init__(self, inserted_ids, acknowledged=True):
             self.__inserted_ids = inserted_ids
-            super(InsertManyResult, self).__init__(acknowledged)
+            super().__init__(acknowledged)
 
         @property
         def inserted_ids(self):
@@ -44,7 +44,7 @@ except ImportError:
 
         def __init__(self, raw_result, acknowledged=True):
             self.__raw_result = raw_result
-            super(UpdateResult, self).__init__(acknowledged)
+            super().__init__(acknowledged)
 
         @property
         def raw_result(self):
@@ -70,7 +70,7 @@ except ImportError:
 
         def __init__(self, raw_result, acknowledged=True):
             self.__raw_result = raw_result
-            super(DeleteResult, self).__init__(acknowledged)
+            super().__init__(acknowledged)
 
         @property
         def raw_result(self):
@@ -86,7 +86,7 @@ except ImportError:
 
         def __init__(self, bulk_api_result, acknowledged):
             self.__bulk_api_result = bulk_api_result
-            super(BulkWriteResult, self).__init__(acknowledged)
+            super().__init__(acknowledged)
 
         @property
         def bulk_api_result(self):
@@ -115,5 +115,13 @@ except ImportError:
         @property
         def upserted_ids(self):
             if self.__bulk_api_result:
-                return dict((upsert['index'], upsert['_id'])
-                            for upsert in self.bulk_api_result['upserted'])
+                return {upsert['index']: upsert['_id']
+                        for upsert in self.bulk_api_result['upserted']}
+
+__all__ = [
+    "BulkWriteResult",
+    "DeleteResult",
+    "InsertManyResult",
+    "InsertOneResult",
+    "UpdateResult",
+]

--- a/mongomock/store.py
+++ b/mongomock/store.py
@@ -6,7 +6,7 @@ import mongomock
 from mongomock.thread import RWLock
 
 
-class ServerStore(object):
+class ServerStore:
     """Object holding the data for a whole server (many databases)."""
 
     def __init__(self):
@@ -26,7 +26,7 @@ class ServerStore(object):
         return [name for name, db in self._databases.items() if db.is_created]
 
 
-class DatabaseStore(object):
+class DatabaseStore:
     """Object holding the data for a database (many collections)."""
 
     def __init__(self):
@@ -60,7 +60,7 @@ class DatabaseStore(object):
         return any(col.is_created for col in self._collections.values())
 
 
-class CollectionStore(object):
+class CollectionStore:
     """Object holding the data for a collection."""
 
     def __init__(self, name):
@@ -131,8 +131,7 @@ class CollectionStore(object):
     def documents(self):
         self._remove_expired_documents()
         with self._rwlock.reader():
-            for doc in self._documents.values():
-                yield doc
+            yield from self._documents.values()
 
     def _remove_expired_documents(self):
         for index in self._ttl_indexes.values():

--- a/mongomock/write_concern.py
+++ b/mongomock/write_concern.py
@@ -4,7 +4,7 @@ def _with_default_values(document):
     return dict(document, w=1)
 
 
-class WriteConcern(object):
+class WriteConcern:
     def __init__(self, w=None, wtimeout=None, j=None, fsync=None):
         self._document = {}
         if w is not None:

--- a/tests/test__bulk_operations.py
+++ b/tests/test__bulk_operations.py
@@ -3,16 +3,7 @@ import os
 import mongomock
 from mongomock import helpers
 from packaging import version
-
-try:
-    from unittest import mock
-    _HAVE_MOCK = True
-except ImportError:
-    try:
-        import mock
-        _HAVE_MOCK = True
-    except ImportError:
-        _HAVE_MOCK = False
+from unittest import mock
 
 try:
     import pymongo
@@ -147,7 +138,6 @@ class BulkOperationsTest(TestCase):
         self.__check_document({'a': 2}, 1)
         self.__check_number_of_elements(1)
 
-    @skipIf(not _HAVE_MOCK, 'The mock library is not installed')
     def test_upsert_replace_one_on_empty_set(self):
         self.bulk_op.find({}).upsert().replace_one({'x': 1})
         self.__execute_and_check_result(nUpserted=1, upserted=[{'index': 0, '_id': mock.ANY}])
@@ -161,7 +151,6 @@ class BulkOperationsTest(TestCase):
         self.__check_document({'x': 1}, 1)
         self.__check_number_of_elements(2)
 
-    @skipIf(not _HAVE_MOCK, 'The mock library is not installed')
     def test_upsert_update_on_empty_set(self):
         self.bulk_op.find({}).upsert().update({'$set': {'a': 1, 'b': 2}})
         self.__execute_and_check_result(nUpserted=1, upserted=[{'index': 0, '_id': mock.ANY}])

--- a/tests/test__client_api.py
+++ b/tests/test__client_api.py
@@ -1,20 +1,10 @@
+import mongomock
+from mongomock import helpers
 from packaging import version
 import sys
 import unittest
 from unittest import skipIf, skipUnless
-
-try:
-    from unittest import mock
-    _HAVE_MOCK = True
-except ImportError:
-    try:
-        import mock
-        _HAVE_MOCK = True
-    except ImportError:
-        _HAVE_MOCK = False
-
-import mongomock
-from mongomock import helpers
+from unittest import mock
 
 try:
     from bson import codec_options
@@ -133,7 +123,6 @@ class MongoClientApiTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             mongomock.MongoClient('localhost:mongoport')
 
-    @unittest.skipIf(not _HAVE_MOCK, 'mock not installed')
     def test_database_names(self):
         client = mongomock.MongoClient()
         client.one_db.my_collec.insert_one({})

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -14,16 +14,7 @@ import warnings
 
 import mongomock
 from mongomock import helpers
-
-try:
-    from unittest import mock
-    _HAVE_MOCK = True
-except ImportError:
-    try:
-        import mock
-        _HAVE_MOCK = True
-    except ImportError:
-        _HAVE_MOCK = False
+from unittest import mock
 
 try:
     from bson import codec_options
@@ -1487,7 +1478,6 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_one({'value': ['a', 'b', 'c', 1, 2, 3]})
         self.assertEqual(self.db.collection.count_documents({}), 1)
 
-    @skipIf(not _HAVE_MOCK, 'mock not installed')
     def test__ttl_expiry_with_mock(self):
         now = datetime.utcnow()
         self.db.collection.create_index([('value', 1)], expireAfterSeconds=100)
@@ -6760,9 +6750,6 @@ class CollectionAPITest(TestCase):
             with self.assertRaises(mongomock.OperationFailure):
                 collection.aggregate(item)
 
-    # https://docs.mongodb.com/manual/reference/operator/aggregation/objectToArray/#examples
-    @skipIf(
-        sys.version_info < (3, 6), "It's harder to keep dict sorted in older versions of Python")
     def test_aggregate_object_to_array_with_example(self):
         collection = self.db.collection
 

--- a/tests/test__patch.py
+++ b/tests/test__patch.py
@@ -9,10 +9,7 @@ try:
 except ImportError:
     _HAVE_PYMONGO = False
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import platform
 _USING_PYPY = platform.python_implementation() == 'PyPy'


### PR DESCRIPTION
Use [pyupgrade](https://github.com/asottile/pyupgrade) to remove legacy syntax. This includes

* Update Python 2 style classes e.g. `class Foo(object)`
* Update Python 2 style `super()`, e.g `super(MyClass, self).__init__()`
* Prefer f-strings over `str.format` or %-formatted strings
* Always use `unittest.mock` which is there since Python 3.3. No need for fallbacks.
* Use `yield from` where applicable
