### PR TITLE
Allow custom ClientClass argument on `patch`

### DIFF
--- a/mongomock/__init__.pyi
+++ b/mongomock/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Literal, Sequence, Tuple, Union
+from typing import Any, Callable, Literal, Sequence, Tuple, Union, TypeVar, Type
 from unittest import mock
 
 from bson.objectid import ObjectId as ObjectId
@@ -13,9 +13,12 @@ from pymongo.errors import (
 )
 
 
+_ClientType = TypeVar("_ClientType")
+
 def patch(
         servers: Union[str, Tuple[str, int], Sequence[Union[str, Tuple[str, int]]]] = ...,
         on_new: Literal['error', 'create', 'timeout', 'pymongo'] = ...,
+        ClientClass: Type[_ClientType] = ...,
         ) -> mock._patch:
     ...
 

--- a/mongomock/patch.py
+++ b/mongomock/patch.py
@@ -28,7 +28,7 @@ def _parse_any_host(host, default_port=27017):
     return split_hosts(host, default_port=default_port)
 
 
-def patch(servers='localhost', on_new='error'):
+def patch(servers='localhost', on_new='error', ClientClass = MongoClient):
     """Patch pymongo.MongoClient.
 
     This will patch the class MongoClient and use mongomock to mock MongoDB
@@ -44,6 +44,9 @@ def patch(servers='localhost', on_new='error'):
     ```
 
     The data is persisted as long as the patch lives.
+
+    You can use a custom MongoMock client class through the ClientClass argument.
+    By default it uses the `mongomock.mongo_client.MongoClient` class.
 
     Args:
         on_new: Behavior when accessing a new server (not in servers):
@@ -72,7 +75,7 @@ def patch(servers='localhost', on_new='error'):
         if _IMPORT_PYMONGO_ERROR:
             raise _IMPORT_PYMONGO_ERROR  # pylint: disable=raising-bad-type
 
-        client = MongoClient(*args, **kwargs)
+        client = ClientClass(*args, **kwargs)
 
         try:
             persisted_client = persisted_clients[client.address]


### PR DESCRIPTION
Hi, this came up as a solution to deal with limitations with the `mongomock` api - namely not supporting transactions and sessions. I understand the decision to raise an error from the lib side, but I still think it should be possible to use the other features if the user chooses to. In my case I created a class that "pretends" to initiate a transaction for testing:

```python
class MongoMockClientWithSession(mongomock.MongoClient):
    """Mongomock does not implement sessions, so we mock it here. This means that
    the atomicity is not actually tested.
    """

    @contextmanager
    def start_session(self, *args, **kwargs):
        yield self

    @contextmanager
    def start_transaction(self, *args, **kwargs):
        yield
```

And used it in my tests with `mongomock.patch`:

```python
@pytest.fixture(autouse=True)
def mock_mongo(): 
    with patch_mongoclient("testhost", "create", ClientClass=MongoMockClientWithSession):
            yield
```

So the transactions are not actually tested but can still perform the tests on the other code functionality.

If this is not wanted no problem, just thought it could be a nice feature.