### PR TITLE
Fix collection.find_one(...) sorting using dicts

### DIFF
--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -1062,6 +1062,8 @@ class Collection(object):
     def _get_dataset(self, spec, sort, fields, as_class):
         dataset = self._iter_documents(spec)
         if sort:
+            if isinstance(sort, dict):
+                sort = sort.items()
             for sort_key, sort_direction in reversed(sort):
                 if sort_key == '$natural':
                     if sort_direction < 0:

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -648,13 +648,13 @@ class CollectionAPITest(TestCase):
         self.assert_documents(documents, ignore_ids=False)
 
         doc = self.db.collection.find_one(
-            {'x': 1}, sort={'x': -1}
+            {'x': 1}, sort={'s': -1}
         )
 
         self.assertDictEqual(doc, documents[-2])
 
         doc = self.db.collection.find_one(
-            {'x': 1}, sort={'x': 1}
+            {'x': 1}, sort={'s': 1}
         )
 
         self.assertDictEqual(doc, documents[0])

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -635,6 +635,30 @@ class CollectionAPITest(TestCase):
         doc.pop('_id')
         self.assertDictEqual(doc, replacement)
 
+    def test__find_one_sorting(self):
+        documents = [
+            {'x': 1, 's': 0},
+            {'x': 1, 's': 1},
+            {'x': 4, 's': 1},
+            {'x': 1, 's': 2},
+            {'x': 1, 's': 3},
+            {'x': 9, 's': 1}
+        ]
+        self.db.collection.insert_many(documents)
+        self.assert_documents(documents, ignore_ids=False)
+
+        doc = self.db.collection.find_one(
+            {'x': 1}, sort={'x': -1}
+        )
+
+        self.assertDictEqual(doc, documents[-2])
+
+        doc = self.db.collection.find_one(
+            {'x': 1}, sort={'x': 1}
+        )
+
+        self.assertDictEqual(doc, documents[0])
+
     def test__find_one_and_update(self):
         documents = [
             {'x': 1, 's': 0},


### PR DESCRIPTION
When trying to find one element and sorting `collection.find_one(filter, sort={"key", -1})` there is a problem inside `_get_dataset` because

```python
assert list(reversed({"key": -1})) == ["key"]
```
or, with a different syntax:
```python
assert next(reversed({"key": -1})) == "key"
```

So it fails to unpack the `sort_direction`.

This PR addresses that issue by checking if the `sort` argument is a dictionary, as it could also be a list of tuples `(key, direction)` and transforming that dictionary into `dict_items` so that they can be reversed in the same fashion, `(key, direction)`.