### PR TITLE
Drop support for deprecated Python version 3.8

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0] - 2024-11-16
+## [4.4.0] - tbd
 ### Added
-- Support for aggregation pipelines in updates [@maximkir-fl](https://github.com/maximkir-fl)
+- Add support for Python 3.13
 
 ### Changed
 - Remove legacy syntax constructs using `pyupgrade --py39-plus`
 
 ### Removed
 - Remove support for deprecated Python version 3.8
+
+
+## [4.3.0] - 2024-11-16
+### Added
+- Support for aggregation pipelines in updates [@maximkir-fl](https://github.com/maximkir-fl)
+
+### Changed
+- Remove legacy syntax constructs using `pyupgrade --py38-plus`
 
 ### Fixed
 - The Mongo Python driver did refactor the `gridfs` implementation, so that the patched code had to
@@ -30,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove support for deprecated Python versions (everything prior to 3.8)
 
 
+[4.4.0]: https://github.com/mongomock/mongomock/compare/4.3.0...4.4.0
 [4.3.0]: https://github.com/mongomock/mongomock/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/mongomock/mongomock/compare/4.1.3...4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.0] - tbd
 ### Changed
-- Remove legacy syntax constructs using `pyupgrade --py38-plus`
+- Remove legacy syntax constructs using `pyupgrade --py39-plus`
+
+### Removed
+- Remove support for deprecated Python version 3.8
 
 ## [4.2.0] - 2024-09-11
 ### Changed
@@ -20,4 +23,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove support for deprecated Python versions (everything prior to 3.8)
 
 
+[4.3.0]: https://github.com/mongomock/mongomock/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/mongomock/mongomock/compare/4.1.3...4.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN apt-get update \
     libncurses5-dev \
     pipx
 
-ENV PATH /root/.local/bin:${PATH}
+ENV PATH=/root/.local/bin:${PATH}
 RUN pipx ensurepath && pipx install hatch
-RUN hatch python install 3.8 3.9 3.10 3.11 3.12 pypy3.10
+RUN hatch python install 3.9 3.10 3.11 3.12 3.13 pypy3.10

--- a/hatch.toml
+++ b/hatch.toml
@@ -11,7 +11,7 @@ matrix.pymongo.extra-dependencies = [
 ]
 
 [[envs.hatch-test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3"]
 pymongo = ["3", "4", "none"]
 
 [envs.cov]

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -390,7 +390,7 @@ class _Parser:
                 return res
 
         assert isinstance(values, (tuple, list)), \
-            "Parameter to {} must evaluate to a list, got '{}'".format(operator, type(values))
+            f"Parameter to {operator} must evaluate to a list, got '{type(values)}'"
 
         parsed_values = list(self.parse_many(values))
         assert parsed_values, '%s must have at least one parameter' % operator
@@ -1449,7 +1449,7 @@ def _combine_projection_spec(filter_list, original_filter, prefix=''):
         filter_dict[field] = filter_dict.get(field, []) + [subkey]
 
     return collections.OrderedDict(
-        (k, _combine_projection_spec(v, original_filter, prefix='{}{}.'.format(prefix, k)))
+        (k, _combine_projection_spec(v, original_filter, prefix=f'{prefix}{k}.'))
         for k, v in filter_dict.items()
     )
 

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -204,7 +204,7 @@ def _combine_projection_spec(projection_fields_spec):
             if not isinstance(tmp_spec.get(base_field), dict):
                 if base_field in tmp_spec:
                     raise OperationFailure(
-                        'Path collision at {} remaining portion {}'.format(f, new_field))
+                        f'Path collision at {f} remaining portion {new_field}')
                 tmp_spec[base_field] = OrderedDict()
             tmp_spec[base_field][new_field] = v
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "packaging",
@@ -49,7 +49,6 @@ source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["mongomock"]
-
 
 [tool.pylint."messages control"]
 disable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     { name = "Martin Domke", email = "mail@martindomke.net" },
     { name = "Pascal Corpet", email = "pascal@corpet.net" },
 ]
+requires-python = ">=3.9"
 classifiers = [
     "License :: OSI Approved :: ISC License (ISCL)",
     "Topic :: Database",

--- a/tests/diff.py
+++ b/tests/diff.py
@@ -11,7 +11,7 @@ except ImportError:
     _HAVE_PYMONGO = False
 
 
-class _NO_VALUE(object):
+class _NO_VALUE:
     pass
 
 
@@ -65,10 +65,10 @@ def diff(a, b, path=None):
         return [(path[:], a, b)]
     if not isinstance(a, _SUPPORTED_TYPES):
         raise NotImplementedError(
-            'Unsupported diff type: {0}'.format(type(a)))  # pragma: no cover
+            f'Unsupported diff type: {type(a)}')  # pragma: no cover
     if not isinstance(b, _SUPPORTED_TYPES):
         raise NotImplementedError(
-            'Unsupported diff type: {0}'.format(type(b)))  # pragma: no cover
+            f'Unsupported diff type: {type(b)}')  # pragma: no cover
     if a != b:
         return [(path[:], a, b)]
     return []

--- a/tests/multicollection.py
+++ b/tests/multicollection.py
@@ -8,10 +8,10 @@ from mongomock.helpers import RE_TYPE
 _COMPARE_EXCEPTIONS = 'exceptions'
 
 
-class MultiCollection(object):
+class MultiCollection:
 
     def __init__(self, conns):
-        super(MultiCollection, self).__init__()
+        super().__init__()
         self.conns = conns.copy()
         self.do = Foreach(self.conns, compare=False)
         self.compare = Foreach(self.conns, compare=True)
@@ -20,7 +20,7 @@ class MultiCollection(object):
         self.compare_exceptions = Foreach(self.conns, compare=_COMPARE_EXCEPTIONS)
 
 
-class Foreach(object):
+class Foreach:
 
     def __init__(self, objs, compare, ignore_order=False,
                  method_result_decorators=()):
@@ -51,7 +51,7 @@ class Foreach(object):
             self.___decorators + list(decorators))
 
 
-class ForeachMethod(object):
+class ForeachMethod:
 
     def __init__(self, objs, compare, ignore_order, method_name, decorators, sort_by):
         self.___objs = objs
@@ -76,15 +76,15 @@ class ForeachMethod(object):
 
     def __call__(self, *args, **kwargs):
         if self.___compare == _COMPARE_EXCEPTIONS:
-            results = dict(
-                (name, self._get_exception_type(obj, args, kwargs, name=name))
+            results = {
+                name: self._get_exception_type(obj, args, kwargs, name=name)
                 for name, obj in self.___objs.items()
-            )
+            }
         else:
-            results = dict(
-                (name, self._call(obj, args, kwargs))
+            results = {
+                name: self._call(obj, args, kwargs)
                 for name, obj in self.___objs.items()
-            )
+            }
         if self.___compare:
             _assert_no_diff(results, ignore_order=self.___ignore_order, sort_by=self.___sort_by)
         return results

--- a/tests/test__bulk_operations.py
+++ b/tests/test__bulk_operations.py
@@ -48,14 +48,14 @@ class BulkOperationsTest(TestCase):
             if self.test_with_pymongo and key == 'nModified' and has_val is None:
                 # ops, real pymongo did not returned 'nModified' key!
                 continue
-            self.assertFalse(has_val is None, "Missed key '{}' in result: {}".format(key, result))
+            self.assertFalse(has_val is None, f"Missed key '{key}' in result: {result}")
             if exp_val:
                 self.assertEqual(
                     exp_val, has_val, 'Invalid result {}={} (but expected value={})'.format(
                         key, has_val, exp_val))
             else:
                 self.assertFalse(
-                    bool(has_val), 'Received unexpected value {} = {}'.format(key, has_val))
+                    bool(has_val), f'Received unexpected value {key} = {has_val}')
 
     def __execute_and_check_result(self, write_concern=None, **expecting_result):
         result = self.bulk_op.execute(write_concern=write_concern)

--- a/tests/test__bulk_operations.py
+++ b/tests/test__bulk_operations.py
@@ -64,7 +64,7 @@ class BulkOperationsTest(TestCase):
     def __check_number_of_elements(self, count):
         has_count = self.db.collection.count()
         self.assertEqual(
-            has_count, count, 'There is {} documents but there should be {}'.format(has_count, count))
+            has_count, count, f'There is {has_count} documents but there should be {count}')
 
     def test__insert(self):
         self.bulk_op.insert({'a': 1, 'b': 2})

--- a/tests/test__bulk_operations.py
+++ b/tests/test__bulk_operations.py
@@ -21,7 +21,7 @@ class BulkOperationsTest(TestCase):
     test_with_pymongo = False
 
     def setUp(self):
-        super(BulkOperationsTest, self).setUp()
+        super().setUp()
         if self.test_with_pymongo:
             self.client = pymongo.MongoClient(host=os.environ.get('TEST_MONGO_HOST', 'localhost'))
         else:
@@ -48,14 +48,14 @@ class BulkOperationsTest(TestCase):
             if self.test_with_pymongo and key == 'nModified' and has_val is None:
                 # ops, real pymongo did not returned 'nModified' key!
                 continue
-            self.assertFalse(has_val is None, "Missed key '%s' in result: %s" % (key, result))
+            self.assertFalse(has_val is None, "Missed key '{}' in result: {}".format(key, result))
             if exp_val:
                 self.assertEqual(
-                    exp_val, has_val, 'Invalid result %s=%s (but expected value=%s)' % (
+                    exp_val, has_val, 'Invalid result {}={} (but expected value={})'.format(
                         key, has_val, exp_val))
             else:
                 self.assertFalse(
-                    bool(has_val), 'Received unexpected value %s = %s' % (key, has_val))
+                    bool(has_val), 'Received unexpected value {} = {}'.format(key, has_val))
 
     def __execute_and_check_result(self, write_concern=None, **expecting_result):
         result = self.bulk_op.execute(write_concern=write_concern)
@@ -64,7 +64,7 @@ class BulkOperationsTest(TestCase):
     def __check_number_of_elements(self, count):
         has_count = self.db.collection.count()
         self.assertEqual(
-            has_count, count, 'There is %s documents but there should be %s' % (has_count, count))
+            has_count, count, 'There is {} documents but there should be {}'.format(has_count, count))
 
     def test__insert(self):
         self.bulk_op.insert({'a': 1, 'b': 2})
@@ -188,7 +188,7 @@ class BulkOperationsWithPymongoTest(BulkOperationsTest):
 class CollectionComparisonTest(TestCase):
 
     def setUp(self):
-        super(CollectionComparisonTest, self).setUp()
+        super().setUp()
         self.fake_conn = mongomock.MongoClient()
         self.mongo_conn = pymongo.MongoClient(host=os.environ.get('TEST_MONGO_HOST', 'localhost'))
         self.db_name = 'mongomock___testing_db'

--- a/tests/test__client_api.py
+++ b/tests/test__client_api.py
@@ -8,7 +8,7 @@ try:
     _HAVE_MOCK = True
 except ImportError:
     try:
-        import mock
+        from unittest import mock
         _HAVE_MOCK = True
     except ImportError:
         _HAVE_MOCK = False

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -55,7 +55,7 @@ class UTCPlus2(tzinfo):
 class CollectionAPITest(TestCase):
 
     def setUp(self):
-        super(CollectionAPITest, self).setUp()
+        super().setUp()
         self.client = mongomock.MongoClient()
         self.db = self.client['somedb']
 
@@ -64,7 +64,7 @@ class CollectionAPITest(TestCase):
         self.assertEqual(self.db.a.b.full_name, 'somedb.a.b')
         self.assertEqual(self.db.a.b.name, 'a.b')
 
-        self.assertEqual(set(self.db.list_collection_names()), set(['a.b']))
+        self.assertEqual(set(self.db.list_collection_names()), {'a.b'})
 
     def test__get_subcollections_by_attribute_underscore(self):
         with self.assertRaises(AttributeError) as err_context:
@@ -110,7 +110,7 @@ class CollectionAPITest(TestCase):
         self.db.drop_collection('b')
         self.db.drop_collection('b')
         self.db.drop_collection(self.db.c)
-        self.assertEqual(set(self.db.list_collection_names()), set(['a']))
+        self.assertEqual(set(self.db.list_collection_names()), {'a'})
 
         col = self.db.a
         r = col.insert_one({'aa': 'bb'}).inserted_id
@@ -181,7 +181,7 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_many(
             [{'f1': ['v1', 'v2', 'v1']}, {'f1': ['v2', 'v3']}])
         cursor = self.db.collection.find()
-        self.assertEqual(set(cursor.distinct('f1')), set(['v1', 'v2', 'v3']))
+        self.assertEqual(set(cursor.distinct('f1')), {'v1', 'v2', 'v3'})
 
     def test__distinct_array_nested_field(self):
         self.db.collection.insert_one({'f1': [{'f2': 'v'}, {'f2': 'w'}]})
@@ -208,7 +208,7 @@ class CollectionAPITest(TestCase):
         self.db.collection.insert_many(
             [{'f1': 'v1', 'k1': 'v1'}, {'f1': 'v2', 'k1': 'v1'},
              {'f1': 'v3', 'k1': 'v2'}])
-        self.assertEqual(set(self.db.collection.distinct('f1', {'k1': 'v1'})), set(['v1', 'v2']))
+        self.assertEqual(set(self.db.collection.distinct('f1', {'k1': 'v1'})), {'v1', 'v2'})
 
     def test__distinct_error(self):
         with self.assertRaises(TypeError):
@@ -306,7 +306,7 @@ class CollectionAPITest(TestCase):
 
             def __init__(self, collection):
                 self.collection = collection
-                super(Document, self).__init__()
+                super().__init__()
                 self.save()
 
             def save(self):
@@ -1267,7 +1267,7 @@ class CollectionAPITest(TestCase):
         self.db['coll_name'].insert_many([larry_bob, larry, gary])
         ret_val = self.db['coll_name'].find().distinct('name')
         self.assertIsInstance(ret_val, list)
-        self.assertTrue(set(ret_val) == set(['larry', 'gary']))
+        self.assertTrue(set(ret_val) == {'larry', 'gary'})
 
     def test__cursor_limit(self):
         self.db.collection.insert_many([{'a': i} for i in range(100)])
@@ -2379,7 +2379,7 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual('collection', coll.name)
         self.assertEqual(
-            set(['other_name']), set(self.db.list_collection_names()))
+            {'other_name'}, set(self.db.list_collection_names()))
         self.assertNotEqual(coll, self.db.other_name)
         self.assertEqual([], list(coll.find()))
         data_in_db = self.db.other_name.find()
@@ -2401,7 +2401,7 @@ class CollectionAPITest(TestCase):
         coll = self.db.create_collection('a')
         self.db.create_collection('c')
         coll.rename('c', dropTarget=True)
-        self.assertEqual(set(['c']), set(self.db.list_collection_names()))
+        self.assertEqual({'c'}, set(self.db.list_collection_names()))
 
     def test__cursor_rewind(self):
         coll = self.db.create_collection('a')
@@ -4018,11 +4018,11 @@ class CollectionAPITest(TestCase):
             ),
             (
                 {'$switch': {'branches': [{'case': True, 'then': 3}, 7]}},
-                '$switch expected each branch to be an object, found: %s' % type(0),
+                '$switch expected each branch to be an object, found: %s' % int,
             ),
             (
                 {'$switch': {'branches': [7, {}]}},
-                '$switch expected each branch to be an object, found: %s' % type(0),
+                '$switch expected each branch to be an object, found: %s' % int,
             ),
             (
                 {'$switch': {'branches': [{'case': False, 'then': 3}]}},
@@ -4831,7 +4831,7 @@ class CollectionAPITest(TestCase):
                 {'$project': {'size': {'$size': 'arr'}}}
             ])
         self.assertEqual(
-            'The argument to $size must be an array, but was of type: %s' % type('arr'),
+            'The argument to $size must be an array, but was of type: %s' % str,
             str(err.exception))
 
     def test__array_size_argument_array(self):
@@ -7060,8 +7060,8 @@ class CollectionAPITest(TestCase):
             {'_id': 1, 'arr': [0, 2, 4, 6]},
             {'_id': 2, 'arr': [1, 3, 5, 7]}
         ])
-        ids = set(doc['_id'] for doc in self.db.collection.find(
-            {'arr': {'$elemMatch': {'$lt': 10, '$gt': 4}}}, {'_id': 1}))
+        ids = {doc['_id'] for doc in self.db.collection.find(
+            {'arr': {'$elemMatch': {'$lt': 10, '$gt': 4}}}, {'_id': 1})}
         self.assertEqual({1, 2}, ids)
 
     def test_list_collection_names_filter(self):
@@ -7069,7 +7069,7 @@ class CollectionAPITest(TestCase):
         self.db.create_collection('aggregator')
         for day in range(10):
             new_date = now - timedelta(day)
-            self.db.create_collection('historical_{0}'.format(new_date.strftime('%Y_%m_%d')))
+            self.db.create_collection('historical_{}'.format(new_date.strftime('%Y_%m_%d')))
 
         # test without filter
         self.assertEqual(len(self.db.list_collection_names()), 11)
@@ -7080,7 +7080,7 @@ class CollectionAPITest(TestCase):
         })) == 10
 
         new_date = datetime.now() - timedelta(1)
-        col_name = 'historical_{0}'.format(new_date.strftime('%Y_%m_%d'))
+        col_name = 'historical_{}'.format(new_date.strftime('%Y_%m_%d'))
 
         # test not equal
         self.assertEqual(len(self.db.list_collection_names(filter={'name': {'$ne': col_name}})), 10)

--- a/tests/test__database_api.py
+++ b/tests/test__database_api.py
@@ -193,18 +193,18 @@ class DatabaseAPITest(TestCase):
                 self.database.collection_names()
             return
 
-        self.assertEqual(set(self.database.collection_names()), set(['a', 'b']))
+        self.assertEqual(set(self.database.collection_names()), {'a', 'b'})
 
         self.database.c.drop()
-        self.assertEqual(set(self.database.collection_names()), set(['a', 'b']))
+        self.assertEqual(set(self.database.collection_names()), {'a', 'b'})
 
     def test__list_collection_names(self):
         self.database.create_collection('a')
         self.database.create_collection('b')
-        self.assertEqual(set(self.database.list_collection_names()), set(['a', 'b']))
+        self.assertEqual(set(self.database.list_collection_names()), {'a', 'b'})
 
         self.database.c.drop()
-        self.assertEqual(set(self.database.list_collection_names()), set(['a', 'b']))
+        self.assertEqual(set(self.database.list_collection_names()), {'a', 'b'})
 
     def test__list_collections(self):
         self.database.create_collection('a')
@@ -243,7 +243,7 @@ class DatabaseAPITest(TestCase):
         col = self.database.a
         self.assertEqual(set(self.database.list_collection_names()), set())
         col.insert_one({'foo': 'bar'})
-        self.assertEqual(set(self.database.list_collection_names()), set(['a']))
+        self.assertEqual(set(self.database.list_collection_names()), {'a'})
 
     def test__equality(self):
         self.assertEqual(self.database, self.database)

--- a/tests/test__gridfs.py
+++ b/tests/test__gridfs.py
@@ -19,8 +19,8 @@ except ImportError:
 
 
 try:
-    import pymongo
     from bson.objectid import ObjectId
+    import pymongo
     from pymongo import MongoClient as PymongoClient
 except ImportError:
     ...

--- a/tests/test__gridfs.py
+++ b/tests/test__gridfs.py
@@ -35,7 +35,7 @@ class GridFsTest(TestCase):
         mongomock.gridfs.enable_gridfs_integration()
 
     def setUp(self):
-        super(GridFsTest, self).setUp()
+        super().setUp()
         self.fake_conn = mongomock.MongoClient()
         self.mongo_conn = self._connect_to_local_mongodb()
         self.db_name = 'mongomock___testing_db'
@@ -47,7 +47,7 @@ class GridFsTest(TestCase):
         self.fake_gridfs = gridfs.GridFS(self.fake_conn[self.db_name])
 
     def tearDown(self):
-        super(GridFsTest, self).setUp()
+        super().setUp()
         self.mongo_conn.close()
         self.fake_conn.close()
 
@@ -150,7 +150,7 @@ class GridFsTest(TestCase):
         self.assertEqual(real['chunkSize'], fake['chunkSize'])
         self.assertLessEqual(
             abs(real['uploadDate'] - fake['uploadDate']).seconds, max_delta_seconds,
-            msg='real: %s, fake: %s' % (real['uploadDate'], fake['uploadDate']))
+            msg='real: {}, fake: {}'.format(real['uploadDate'], fake['uploadDate']))
 
     def get_mongo_file(self, i):
         return self.mongo_conn[self.db_name]['fs']['files'].find_one({'_id': i})
@@ -174,7 +174,7 @@ class GridFsTest(TestCase):
                     raise
 
 
-class GenFile(object):
+class GenFile:
     def __init__(self, length, value=0, do_encode=True):
         self.gen = self._gen_data(length, value)
         self.do_encode = do_encode

--- a/tests/test__helpers.py
+++ b/tests/test__helpers.py
@@ -107,7 +107,7 @@ def create_uri_spec_tests():
                 scenario_def = json.load(scenario_stream)
             # Construct test from scenario.
             new_test = create_uri_spec_test(scenario_def)
-            test_name = 'test_%s_%s' % (
+            test_name = 'test_{}_{}'.format(
                 dirname, os.path.splitext(filename)[0])
             new_test.__name__ = test_name
             setattr(TestAllUriScenarios, new_test.__name__, new_test)

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import OrderedDict
 import copy
 import datetime
@@ -87,7 +86,7 @@ class InterfaceTest(TestCase):
 class DatabaseGettingTest(TestCase):
 
     def setUp(self):
-        super(DatabaseGettingTest, self).setUp()
+        super().setUp()
         self.client = mongomock.MongoClient()
 
     @skipIf(not helpers.HAVE_PYMONGO, 'pymongo not installed')
@@ -270,7 +269,7 @@ class _CollectionComparisonTest(TestCase):
     """
 
     def setUp(self):
-        super(_CollectionComparisonTest, self).setUp()
+        super().setUp()
         self.fake_conn = mongomock.MongoClient()
         self.mongo_conn = self._connect_to_local_mongodb()
         self.db_name = 'mongomock___testing_db'
@@ -309,7 +308,7 @@ class _CollectionComparisonTest(TestCase):
                     raise
 
     def tearDown(self):
-        super(_CollectionComparisonTest, self).tearDown()
+        super().tearDown()
         self.mongo_conn.close()
 
 
@@ -2385,7 +2384,7 @@ class GroupTest(_CollectionComparisonTest):
 class MongoClientAggregateTest(_CollectionComparisonTest):
 
     def setUp(self):
-        super(MongoClientAggregateTest, self).setUp()
+        super().setUp()
         self.data = [
             {'_id': ObjectId(), 'a': 1, 'b': 1, 'count': 4, 'swallows': ['European swallow'],
              'date': datetime.datetime(2015, 10, 1, 10, 0)},
@@ -2789,12 +2788,12 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
         expected = list(aggregations['real'])
         result = list(aggregations['fake'])
         self.assertEqual(len(result), len(expected))
-        set_expected = set([
+        set_expected = {
             tuple(sorted(e.items())) for elt in expected for e in elt['set']
-        ])
-        set_result = set([
+        }
+        set_result = {
             tuple(sorted(e.items())) for elt in result for e in elt['set']
-        ])
+        }
         self.assertEqual(set_result, set_expected)
 
     def test__aggregate_add_to_set_missing_value(self):
@@ -2878,7 +2877,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             {'_id': 3, 'description': 'Many spaces before     line'},
             {'_id': 4, 'description': 'Multiple\nline descriptions'},
             {'_id': 5, 'description': 'anchors, links and hyperlinks'},
-            {'_id': 6, 'description': u'métier work vocation'}
+            {'_id': 6, 'description': 'métier work vocation'}
         ])
         self.cmp.compare.aggregate([{'$addFields': {
             'result': {'$regexMatch': {'input': '$description', 'regex': 'line'}},
@@ -4281,7 +4280,7 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
 class MongoClientGraphLookupTest(_CollectionComparisonTest):
 
     def setUp(self):
-        super(MongoClientGraphLookupTest, self).setUp()
+        super().setUp()
         self.cmp_a = self._create_compare_for_collection('data_a')
         self.cmp_b = self._create_compare_for_collection('data_b')
 
@@ -4469,7 +4468,7 @@ def _SKIP(*args):
 class MongoClientSortSkipLimitTest(_CollectionComparisonTest):
 
     def setUp(self):
-        super(MongoClientSortSkipLimitTest, self).setUp()
+        super().setUp()
         self.cmp.do.insert_many([{'_id': i, 'index': i} for i in range(30)])
 
     def test__skip(self):
@@ -4597,7 +4596,7 @@ class MongoClientSortSkipLimitTest(_CollectionComparisonTest):
 class InsertedDocumentTest(TestCase):
 
     def setUp(self):
-        super(InsertedDocumentTest, self).setUp()
+        super().setUp()
         self.collection = mongomock.MongoClient().db.collection
         self.data = {'a': 1, 'b': [1, 2, 3], 'c': {'d': 4}}
         self.orig_data = copy.deepcopy(self.data)
@@ -4656,7 +4655,7 @@ class MongoClientTest(_CollectionComparisonTest):
     """
 
     def setUp(self):
-        super(MongoClientTest, self).setUp()
+        super().setUp()
         self.cmp = MultiCollection({'fake': self.fake_conn, 'real': self.mongo_conn})
 
     def test__database_names(self):
@@ -4674,7 +4673,7 @@ class DatabaseTest(_CollectionComparisonTest):
     """
 
     def setUp(self):
-        super(DatabaseTest, self).setUp()
+        super().setUp()
         self.cmp = MultiCollection({
             'fake': self.fake_conn[self.db_name],
             'real': self.mongo_conn[self.db_name],

--- a/tests/types/patch.py
+++ b/tests/types/patch.py
@@ -2,10 +2,10 @@ import mongomock
 
 
 @mongomock.patch(servers=(('server.example.com', 27017),))
-class MyTestA(object):
+class MyTestA:
     ...
 
 
 @mongomock.patch(('mydata.com', 'myprivatedata.com'))
-class MyTestB(object):
+class MyTestB:
     ...

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-class DBRef(object):
+class DBRef:
 
     def __init__(self, collection, id, database=None):
         self.collection = collection


### PR DESCRIPTION
Python 3.8 has reached [end-of-life status](https://devguide.python.org/versions/) in October 2024, so that we don't officially support it anymore with this library. Supporting old versions is always painful for library maintainers, because you cannot take advantage of features and improvements of the language, even though they have been added years ago.