### PR TITLE
add support for comment on bulk_write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 .tox
 .cache/
 .pytest_cache/
+.idea/

--- a/mongomock/collection.py
+++ b/mongomock/collection.py
@@ -2131,7 +2131,12 @@ class Collection:
             raise_not_implemented('session', 'Mongomock does not handle sessions yet')
         return self.database.rename_collection(self.name, new_name, **kwargs)
 
-    def bulk_write(self, requests, ordered=True, bypass_document_validation=False, session=None):
+    def bulk_write(
+        self, requests, ordered=True, bypass_document_validation=False, session=None, comment=None
+    ):
+        if comment:
+            warnings.warn('comment is ignored on mongomock.', stacklevel=2)
+
         if bypass_document_validation:
             raise NotImplementedError(
                 'Skipping document validation is a valid MongoDB operation;'

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2769,7 +2769,7 @@ class CollectionAPITest(TestCase):
 
         # Upsert == True
         operations = [pymongo.UpdateMany({'a': 2}, {'$set': {'a': 3}}, upsert=True)]
-        result = self.db.collection.bulk_write(operations)
+        result = self.db.collection.bulk_write(operations, comment='bulk comment')
 
         docs = list(self.db.collection.find({'a': 3}))
         self.assertEqual(len(docs), 1)


### PR DESCRIPTION
I've been using mongomock together with mongomock-motor and beanie.

In recent versions of MongoDB support for [comment](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/write/bulk-write/#collection-bulk-write-options) has been added on bulk write operations.

However, if this parameter is sent to the current implementation of bulk_write, it breaks.

This PR basically accepts the parameter and logs a warning letting the user know that it is ignored on mongomock.