### PR TITLE
Fix matching whole array when using $in operator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,7 +139,7 @@ When submitting a PR, please make sure that:
 3. The code is auto-formatted (``hatch fmt``).
 4. The build passes on your PR.
 
-To download, setup and perfom tests, run the following commands on Mac / Linux:
+To download, setup and perform tests, run the following commands on Mac / Linux:
 
 .. code-block:: console
 

--- a/mongomock/filtering.py
+++ b/mongomock/filtering.py
@@ -295,7 +295,7 @@ def _in_op(doc_val, search_val):
     doc_val = _force_list(doc_val)
     is_regex_list = [isinstance(x, _RE_TYPES) for x in search_val]
     if not any(is_regex_list):
-        return any(x in search_val for x in doc_val)
+        return any(x in search_val for x in doc_val) or doc_val in search_val
     for x, is_regex in zip(search_val, is_regex_list):
         if (is_regex and _regex(doc_val, x)) or (x in doc_val):
             return True

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -643,6 +643,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare.find({'array_field': [['abc']]})
         self.cmp.compare.find({'array_field': 'def'})
         self.cmp.compare.find({'array_field': ['def']})
+        self.cmp.compare.find({'array_field': {'$in': [['def'], [['abc']]]}})
 
     def test__find_by_objectid_in_list(self):
         # See #79


### PR DESCRIPTION
Selecting a list value in `$in` query fails in mongomock, but works in MongoDB.

Similar to issue fixed in PR #91, but for the case when list of lists in passed as value for `$in` query.

For example when the doc is
`{'array_field': ['abc']}` and the query is `{'array_field': {'$in': [['abc']]}}` mongomock returns an empty result, while the same query works in MongoDB.