### PR TITLE
add examples basic query, and aggregation with mongomock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,13 @@ mongomock.patch (NOTE: you should use :code:`pymongo.MongoClient(...)` rather th
     call_endpoint('/votes')
     ... verify client.db.collection
 
+Usage Examples
+--------------
+
+You can find runnable example scripts under the ``examples/`` folder.
+They demonstrate basic usage of mongomock for testing code without
+a real MongoDB instance.
+
 
 Important Note About Project Status & Development
 -------------------------------------------------

--- a/examples/mongomock_aggregation.py
+++ b/examples/mongomock_aggregation.py
@@ -1,0 +1,19 @@
+from mongomock.mongo_client import MongoClient
+
+
+def main():
+    db = MongoClient().db
+    orders = db.orders
+    orders.insert_many(
+        [
+            {'item': 'apple', 'qty': 5},
+            {'item': 'apple', 'qty': 3},
+            {'item': 'banana', 'qty': 7},
+        ]
+    )
+    result = list(orders.aggregate([{'$group': {'_id': '$item', 'total': {'$sum': '$qty'}}}]))
+    print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/mongomock_basic_query.py
+++ b/examples/mongomock_basic_query.py
@@ -1,0 +1,14 @@
+from mongomock.mongo_client import MongoClient
+
+
+def main():
+    client = MongoClient()
+    db = client['test_db']
+    users = db['users']
+    users.insert_one({'name': 'Alice', 'age': 30})
+    user = users.find_one({'name': 'Alice'})
+    print(user)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds runnable example scripts inside the examples/ directory to demonstrate usage of mongomock:

The examples can be run with python -m examples.<module_name>, providing an easy way for users to understand how to test MongoDB interactions without a real database.

Additionally, the README is updated.