### PR TITLE
feat: support  in aggregation pipeline

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -275,7 +275,9 @@ class _Parser:
                 return self._handle_type_operator(k, v)
             if k in boolean_operators:
                 return self._handle_boolean_operator(k, v)
-            if k in text_search_operators + projection_operators + object_operators:
+            if k in object_operators:
+                return self._handle_object_operator(k, v)
+            if k in text_search_operators + projection_operators:
                 raise NotImplementedError(
                     f"'{k}' is a valid operation but it is not supported by Mongomock yet."
                 )
@@ -300,6 +302,28 @@ class _Parser:
                     yield None
                 else:
                     raise
+
+    def _handle_object_operator(self, operator, expression):
+        if operator == '$mergeObjects':
+            return self._merge_objects(expression)
+
+    def _merge_objects(self, docs):
+        """
+        Merges a list of dictionaries into a single dictionary.
+        Ignores values that are not dictionaries.
+        """
+        merged = {}
+        # Parse the expression to resolve any nested operations
+        docs = self.parse(docs) if not isinstance(docs, list) else docs
+    
+        for doc in docs:
+            # Handle all value types
+            parsed = self.parse(doc) if isinstance(doc, dict) else doc
+        
+            if isinstance(parsed, dict):
+                merged.update(parsed)
+    
+        return merged
 
     def _parse_to_bool(self, expression):
         """Parse a MongoDB expression and then convert it to bool"""

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -4704,6 +4704,12 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
                 {'_id': ObjectId(), 'a': 3, 'b': None},
                 {'_id': ObjectId(), 'a': 3, 'b': {}},
                 {'_id': ObjectId(), 'a': 4, 'b': None},
+                {'_id': ObjectId(), 'a': 'multi', 'b': {'x': 1}},
+                {'_id': ObjectId(), 'a': 'multi', 'b': {'y': 2}},
+                {'_id': ObjectId(), 'a': 'multi', 'b': {'z': 3}},
+                {'a': 'non_dict', 'b': {'note': 'was a string'}},   
+                {'_id': ObjectId(), 'a': 'non_dict', 'b': {'valid': True}},
+                {'_id': ObjectId(), 'a': 'empty', 'b': {}}
             ]
         )
         pipeline = [


### PR DESCRIPTION
I've modified and added the inclusion of the $mergeObjects object in the aggregation pipeline. Tests were found in test__mongomock.py, I added a few other cases and they succeeded. I tried testing the whole file, and I got other errors that are not related to my modification. 
If I need to do anything else, let me know ^^.