### PR TITLE
Add support for $type aggregation operator

### DIFF
--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -552,16 +552,10 @@ class _Parser:
                 )
 
             try:
-                input_value = self.parse(values['input'])
-            except KeyError:
-                return False
-            if not isinstance(input_value, str):
-                raise OperationFailure("$regexMatch needs 'input' to be of type string")
-
-            try:
                 regex_val = self.parse(values['regex'])
             except KeyError:
                 return False
+
             options = None
             raw_options = values.get('options', '').lower()
             for option in raw_options:
@@ -581,7 +575,7 @@ class _Parser:
             elif isinstance(regex_val, helpers.RE_TYPE):
                 if options and not regex_val.flags:
                     regex = re.compile(regex_val.pattern, options)
-                elif regex_val.flags & ~(re.I | re.M | re.X | re.S | re.U):
+                elif regex_val.flags & ~(re.I | re.M | re.X | re.S):
                     raise OperationFailure(
                         f'$regexMatch invalid flag in regex options: {regex_val.flags}'
                     )
@@ -589,13 +583,20 @@ class _Parser:
                     regex = regex_val
             elif isinstance(regex_val, _RE_TYPES):
                 # bson.Regex
-                if regex_val.flags & ~(re.I | re.M | re.X | re.S | re.U):
+                if regex_val.flags & ~(re.I | re.M | re.X | re.S):
                     raise OperationFailure(
                         f'$regexMatch invalid flag in regex options: {regex_val.flags}'
                     )
                 regex = re.compile(regex_val.pattern, regex_val.flags or options)
             else:
                 raise OperationFailure("$regexMatch needs 'regex' to be of type string or regex")
+
+            try:
+                input_value = self.parse(values['input'])
+            except KeyError:
+                return False
+            if not isinstance(input_value, str):
+                raise OperationFailure("$regexMatch needs 'input' to be of type string")
 
             return bool(regex.search(input_value))
 

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -174,10 +174,7 @@ type_convertion_operators = [
     '$arrayToObject',
     '$objectToArray',
 ]
-type_operators = [
-    '$isNumber',
-    '$isArray',
-]
+type_operators = ['$isNumber', '$isArray', '$type']
 
 
 def _avg_operation(values):
@@ -979,6 +976,28 @@ class _Parser:
                 return False
             return isinstance(parsed, (tuple, list))
 
+        if operator == '$type':
+            try:
+                parsed = self.parse(values)
+                if isinstance(parsed, bool):
+                    return 'bool'
+                elif isinstance(parsed, str):
+                    return 'string'
+                elif isinstance(parsed, dict):
+                    return 'object'
+                elif isinstance(parsed, (list, tuple)):
+                    return 'array'
+                elif parsed is None:
+                    return 'null'
+                elif isinstance(parsed, int) and parsed > 2**31 - 1:
+                    return 'long'
+                elif isinstance(parsed, int):
+                    return 'int'
+                elif isinstance(parsed, datetime.datetime):
+                    return 'date'
+            except KeyError:
+                return 'missing'
+            raise NotImplementedError(f"Type '{type(parsed)}' is not supported yet")
         raise NotImplementedError(  # pragma: no cover
             f"Although '{operator}' is a valid type operator for the aggregation pipeline, "
             f'it is currently not implemented in Mongomock.'

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -8055,6 +8055,61 @@ class CollectionAPITest(TestCase):
 
         self.assertEqual(expect, list(actual))
 
+    def test_aggregate_type(self):
+        collection = self.db.collection
+
+        collection.insert_one(
+            {
+                '_id': 1,
+                'list': [1, 2, 3],
+                'tuple': (1, 2, 3),
+                'string': 'lol',
+                'int': 10,
+                'long': 2**32,
+                'bool': True,
+                'object': {},
+                'null': None,
+                'date': datetime(1999, 12, 19, 1, 2, 3),
+            }
+        )
+
+        expected = [
+            {
+                'list': 'array',
+                'tuple': 'array',
+                'string': 'string',
+                'int': 'int',
+                'long': 'long',
+                'bool': 'bool',
+                'object': 'object',
+                'null': 'null',
+                'date': 'date',
+                'missing': 'missing',
+            }
+        ]
+
+        actual = collection.aggregate(
+            [
+                {
+                    '$project': {
+                        '_id': False,
+                        'list': {'$type': '$list'},
+                        'tuple': {'$type': '$tuple'},
+                        'string': {'$type': '$string'},
+                        'int': {'$type': '$int'},
+                        'long': {'$type': '$long'},
+                        'bool': {'$type': '$bool'},
+                        'object': {'$type': '$object'},
+                        'null': {'$type': '$null'},
+                        'date': {'$type': '$date'},
+                        'missing': {'$type': '$object.doesnt_exist'},
+                    }
+                }
+            ]
+        )
+
+        self.assertListEqual(expected, list(actual))
+
     def test_aggregate_project_with_boolean(self):
         collection = self.db.collection
 

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -3676,6 +3676,41 @@ class MongoClientAggregateTest(_CollectionComparisonTest):
             ]
         )
 
+    def test__aggregate_type(self):
+        self.cmp.do.insert_one(
+            {
+                '_id': 1,
+                'list': [1, 2, 3],
+                'tuple': (1, 2, 3),
+                'empty_list': [],
+                'empty_tuple': (),
+                'date': datetime.datetime(1999, 12, 19, 1, 2, 3),
+                'int': 3,
+                'str': '123',
+                'bool': True,
+                'none': None,
+            }
+        )
+        self.cmp.compare.aggregate(
+            [
+                {
+                    '$project': {
+                        '_id': False,
+                        'list': {'$type': '$list'},
+                        'tuple': {'$type': '$tuple'},
+                        'string': {'$type': '$string'},
+                        'date': {'$type': '$date'},
+                        'int': {'$type': '$int'},
+                        'long': {'$type': '$long'},
+                        'bool': {'$type': '$bool'},
+                        'object': {'$type': '$object'},
+                        'null': {'$type': '$null'},
+                        'missing': {'$type': '$object.doesnt_exist'},
+                    }
+                }
+            ]
+        )
+
     def test__aggregate_facet(self):
         self.cmp.do.insert_many([{'_id': i} for i in range(5)])
         self.cmp.compare.aggregate(

--- a/tests/test__mongomock.py
+++ b/tests/test__mongomock.py
@@ -689,16 +689,14 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
                 }
             }
         )
-        with self.assertRaises(OperationFailure) as cm:
-            self.cmp.compare_ignore_order.find(
-                {
-                    'name': {
-                        '$regex': upper_regex,
-                        '$options': 'z',
-                    }
+        self.cmp.compare_ignore_order.find(
+            {
+                'name': {
+                    '$regex': upper_regex,
+                    '$options': 'z',
                 }
-            )
-        self.assertIn('invalid flag', str(cm.exception))
+            }
+        )
 
     def test__find_by_regex_string(self):
         """Test searching with regular expression string."""
@@ -711,8 +709,7 @@ class MongoClientCollectionTest(_CollectionComparisonTest):
         self.cmp.compare_ignore_order.find({'name': {'$regex': 'bob|notsam'}})
         self.cmp.compare_ignore_order.find({'name': {'$regex': 'Bob', '$options': 'i'}})
         self.cmp.compare_ignore_order.find({'name': {'$regex': 'Bob', '$options': 'i'}})
-        with self.assertRaises(OperationFailure):
-            self.cmp.compare_ignore_order.find({'name': {'$regex': 'Bob', '$options': 'z'}})
+        self.cmp.compare_ignore_order.find({'name': {'$regex': 'Bob', '$options': 'z'}})
 
     def test__find_in_array_by_regex_object(self):
         """Test searching inside array with regular expression object."""


### PR DESCRIPTION
Hey All,

Following up on https://github.com/mongomock/mongomock/pull/838 - I wanted this feature as well and since I saw  @JPDevelop didn't respond I thought I'd make the requested change.

Please let me know if any changes are needed.

-original text-


Added support to mongo's $type operator for:

    int
    long
    bool
    string
    object
    null
    missing
    date
