### PR TITLE
Remove support for 3.9

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update \
 
 ENV PATH=/root/.local/bin:${PATH}
 RUN pipx ensurepath && pipx install hatch
-RUN hatch python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+RUN hatch python install 3.10 3.11 3.12 3.13 pypy3.10

--- a/hatch.toml
+++ b/hatch.toml
@@ -15,7 +15,7 @@ matrix.pymongo.extra-dependencies = [
 ]
 
 [[envs.hatch-test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3"]
+python = ["3.10", "3.11", "3.12", "3.13", "pypy3"]
 pymongo = ["3", "4", "none"]
 
 [envs.coverage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Martin Domke", email = "mail@martindomke.net" },
     { name = "Pascal Corpet", email = "pascal@corpet.net" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: ISC License (ISCL)",
     "Topic :: Database",
@@ -25,7 +25,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
3.9 is end-of-life since Oct 31, 2025.

Tests fail on 3.14, so don't add it yet.