### PR TITLE
Support adding millisecond offsets to dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove support for deprecated Python version 3.8
 
+### Fixed
+- Support adding numeric millisecond offsets to datetimes in aggregation `$add` expressions.
+
 
 ## [4.3.0] - 2024-11-16
 ### Added

--- a/mongomock/aggregate.py
+++ b/mongomock/aggregate.py
@@ -411,12 +411,25 @@ class _Parser:
 
         parsed_values = list(self.parse_many(values))
         assert parsed_values, f'{operator} must have at least one parameter'
+        if operator == '$add':
+            date_value = None
+            sum_value = 0
+            for value in parsed_values:
+                if value is None:
+                    return None
+                if isinstance(value, datetime.datetime):
+                    assert date_value is None, f'{operator} only accepts one date'
+                    date_value = value
+                else:
+                    assert isinstance(value, numbers.Number), f'{operator} only uses numbers'
+                    sum_value += value
+            if date_value is not None:
+                return date_value + datetime.timedelta(milliseconds=sum_value)
+            return sum_value
         for value in parsed_values:
             if value is None:
                 return None
             assert isinstance(value, numbers.Number), f'{operator} only uses numbers'
-        if operator == '$add':
-            return sum(parsed_values)
         if operator == '$multiply':
             return functools.reduce(lambda x, y: x * y, parsed_values)
 

--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -4487,6 +4487,25 @@ class CollectionAPITest(TestCase):
                 )
             )
 
+    def test__aggregate_add_date_and_milliseconds(self):
+        self.db.collection.insert_one({'date': datetime(2021, 1, 1), 'hour': 6})
+        actual = self.db.collection.aggregate(
+            [
+                {
+                    '$project': {
+                        '_id': False,
+                        'datetime': {'$add': ['$date', {'$multiply': ['$hour', 3600000]}]},
+                        'datetime_reversed': {'$add': [{'$multiply': ['$hour', 3600000]}, '$date']},
+                    }
+                }
+            ]
+        )
+        expected = {
+            'datetime': datetime(2021, 1, 1, 6),
+            'datetime_reversed': datetime(2021, 1, 1, 6),
+        }
+        self.assertEqual([expected], list(actual))
+
     def test__aggregate_project_cond_mongodb_to_bool(self):
         self.db.collection.insert_one({'_id': 1})
         actual = self.db.collection.aggregate(


### PR DESCRIPTION
Fixes #688.

MongoDB allows `$add` to combine one date with numeric operands, treating the numeric values as millisecond offsets. Mongomock currently requires every `$add` operand to be numeric, so the issue reproduction raises an assertion instead of producing the shifted datetime.

This keeps the existing numeric-only `$add` behavior, and adds support for a single datetime plus numeric millisecond offsets. The regression test covers the issue's `$multiply` expression and the same operands in reversed order.

Verification:
- `.venv/bin/hatch fmt --check`
- `.venv/bin/python -m pytest tests/test__collection_api.py`
- `.venv/bin/hatch test tests/test__collection_api.py::CollectionAPITest::test__aggregate_add_date_and_milliseconds`
- Manual reproduction from #688
