### PR TITLE
Make find_and_modify sort test deterministic

### DIFF
--- a/tests/test__collection_api.py
+++ b/tests/test__collection_api.py
@@ -2064,14 +2064,13 @@ class CollectionAPITest(TestCase):
         'find_and_modify was removed in pymongo v4',
     )
     def test__find_and_modify_with_sort(self):
-        self.db.collection.insert_one({'time_check': float(time.time())})
-        self.db.collection.insert_one({'time_check': float(time.time())})
-        self.db.collection.insert_one({'time_check': float(time.time())})
+        for time_check in (1.0, 2.0, 3.0):
+            self.db.collection.insert_one({'time_check': time_check})
 
-        start_check_time = float(time.time())
+        start_check_time = 4.0
         self.db.collection.find_and_modify(
             {'time_check': {'$lt': start_check_time}},
-            {'$set': {'time_check': float(time.time()), 'checked': True}},
+            {'$set': {'time_check': 5.0, 'checked': True}},
             sort=[('time_check', pymongo.ASCENDING)],
         )
         sorted_records = sorted(self.db.collection.find(), key=lambda x: x['time_check'])
@@ -2079,13 +2078,13 @@ class CollectionAPITest(TestCase):
 
         self.db.collection.find_and_modify(
             {'time_check': {'$lt': start_check_time}},
-            {'$set': {'time_check': float(time.time()), 'checked': True}},
+            {'$set': {'time_check': 6.0, 'checked': True}},
             sort=[('time_check', pymongo.ASCENDING)],
         )
 
         self.db.collection.find_and_modify(
             {'time_check': {'$lt': start_check_time}},
-            {'$set': {'time_check': float(time.time()), 'checked': True}},
+            {'$set': {'time_check': 7.0, 'checked': True}},
             sort=[('time_check', pymongo.ASCENDING)],
         )
 


### PR DESCRIPTION
## Summary

- Make `test__find_and_modify_with_sort` deterministic by replacing successive wall-clock timestamps with fixed, ordered values.
- Preserve the test's existing sorting intent while removing its dependency on platform clock resolution.
- This is a test-only change; no production code is modified.

## Root cause

The test inserted and updated documents using successive `time.time()` calls, then assumed that every returned timestamp was strictly increasing. On platforms where multiple calls can return the same value, notably Windows with its clock-resolution behavior, two records can have equal sort keys. The final record selected by the assertion can then be one that was not updated, causing `KeyError: 'checked'`.

Using fixed values keeps the intended ordering explicit and makes the test independent of timing and operating-system clock behavior.

## Validation

- `python -m unittest tests.test__collection_api.CollectionAPITest.test__find_and_modify_with_sort`: 1 test run; OK.
- `python -m unittest tests.test__collection_api`: 428 tests run; suite OK with 6 skipped.
- `python -m unittest discover -s tests`: 892 tests run; suite OK with 349 skipped.
- `ruff check tests/test__collection_api.py`: passed.
- `ruff format --check tests/test__collection_api.py`: passed.
- `git diff --check develop...HEAD`: passed.

## Upstream CI status

In the [initial PR run](https://github.com/mongomock/mongomock/actions/runs/29891808493), both lint jobs and the package build passed. The Python 3.9 test job failed before collecting tests because the current Hatch test environment resolved `coverage[toml]>=7.11`, whose available stable releases no longer satisfy Python 3.9. Matrix fail-fast then cancelled the other Python jobs; Python 3.12 had already reported three regex parity failures in `tests/test__mongomock.py`, outside this diff.

The [most recent `develop` push run](https://github.com/mongomock/mongomock/actions/runs/15984713468) was already red with the Python 3.9 test job failing and the remaining test matrix cancelled. Its retained job logs have expired, so I am not asserting that the historical failure had the identical dependency cause. I have kept this PR focused on the deterministic test change rather than mixing in unrelated CI or regex fixes.